### PR TITLE
Feature/employee-see-earned-points

### DIFF
--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -9,4 +9,8 @@ class Employee < ApplicationRecord
 
   has_many :given_kudos, class_name: 'Kudo', foreign_key: 'giver_id', inverse_of: 'giver', dependent: :destroy
   has_many :received_kudos, class_name: 'Kudo', foreign_key: 'reciever_id', inverse_of: 'reciever', dependent: :destroy
+
+  def points
+    received_kudos.count
+  end
 end

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -20,6 +20,11 @@
         <div class="navbar-item">
           <%= style_avaible_kudos(current_employee.number_of_available_kudos) %>
         </div>
+        <div class=navbar-item">
+          <span class="tag is-large"> 
+            Points: <%= current_employee.points %>
+          </span>
+        </div>
         <%= display_curent_users_email_on_test_or_development(current_employee) %>
         <div class="navbar-item">
           <div class="buttons">

--- a/spec/system/employee/earned_points_spec.rb
+++ b/spec/system/employee/earned_points_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe 'Employee earned points', type: :system do
+  let(:employee) { create(:employee) }
+
+  context 'when emplyee is signed in' do
+    it 'Navbar displays earned points for employee' do
+      sign_in employee
+      visit root_path
+      expect(page).to have_content 'Points: 0'
+      kudo = create(:kudo, reciever: employee)
+      visit current_path
+      expect(page).to have_content 'Points: 1'
+      kudo.destroy
+      visit current_path
+      expect(page).to have_content 'Points: 0'
+    end
+  end
+end


### PR DESCRIPTION
Sprint 4. task 1

Employees can see point earned on navbar.
Points earned are equal to recieved kudos count

PR adds:
- method in Employee model to count points
- element in navbar to diplay points
- system spec

![points-navbar-display](https://user-images.githubusercontent.com/22965927/172174106-d3fb24ee-a2b8-4406-a41a-bd6b678a1c54.gif)