### PR TITLE
Feature/employee-can-buy-reward

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,18 +1,12 @@
 class OrdersController < EmployeeBaseController
   def create
-    reward = Reward.find(params[:reward])
-    if current_employee.points < reward.price
-      redirect_to reward_path(reward),
-                  alert: 'Not enough points for this reward' and return
-    end
-
     @order = Order.new(reward_id: order_params)
     @order.employee = current_employee
     if @order.save
       redirect_to rewards_path, notice: 'You have bought a reward!'
     else
-      flash[:notice] = 'Something went wrong'
-      redirect_back
+      flash[:alert] = @order.errors[:can_not_afford].join('. ')
+      redirect_back fallback_location: rewards_path
     end
   end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,24 @@
+class OrdersController < EmployeeBaseController
+  def create
+    reward = Reward.find(params[:reward])
+    if current_employee.points < reward.price
+      redirect_to reward_path(reward),
+                  alert: 'Not enough points for this reward' and return
+    end
+
+    @order = Order.new(reward_id: order_params)
+    @order.employee = current_employee
+    if @order.save
+      redirect_to rewards_path, notice: 'You have bought a reward!'
+    else
+      flash[:notice] = 'Something went wrong'
+      redirect_back
+    end
+  end
+
+  private
+
+  def order_params
+    params.require(:reward)
+  end
+end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -10,7 +10,7 @@ class Employee < ApplicationRecord
   has_many :given_kudos, class_name: 'Kudo', foreign_key: 'giver_id', inverse_of: 'giver', dependent: :destroy
   has_many :received_kudos, class_name: 'Kudo', foreign_key: 'reciever_id', inverse_of: 'reciever', dependent: :destroy
   has_many :orders, dependent: :destroy
-  has_many :rewards, through: :orders, dependent: :destroy
+  has_many :rewards, through: :orders
 
   def points
     received_kudos.count - rewards.sum(:price)

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -9,8 +9,10 @@ class Employee < ApplicationRecord
 
   has_many :given_kudos, class_name: 'Kudo', foreign_key: 'giver_id', inverse_of: 'giver', dependent: :destroy
   has_many :received_kudos, class_name: 'Kudo', foreign_key: 'reciever_id', inverse_of: 'reciever', dependent: :destroy
+  has_many :orders, dependent: :destroy
+  has_many :rewards, through: :orders, dependent: :destroy
 
   def points
-    received_kudos.count
+    received_kudos.count - rewards.sum(:price)
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,4 @@
+class Order < ApplicationRecord
+  belongs_to :employee
+  belongs_to :reward
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,4 +1,12 @@
 class Order < ApplicationRecord
   belongs_to :employee
   belongs_to :reward
+
+  validate :can_employee_afford_price, on: :create
+
+  def can_employee_afford_price
+    return unless reward.present? && employee.present? && (reward.price > employee.points)
+
+    errors.add(:can_not_afford, 'You can not afford this reward')
+  end
 end

--- a/app/views/rewards/show.html.erb
+++ b/app/views/rewards/show.html.erb
@@ -12,6 +12,7 @@
     </p>
 
     <div class='mt-3'>
+      <%= link_to 'CLAIM REWARD!', orders_path(reward: @reward), method: :post, data: { confirm: 'Are you sure?' }, class: 'button is-primary' %>
       <%= link_to 'Back', rewards_path, class: 'button' %>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   
   resources :kudos
   resources :rewards, only: %i[index show]
-  resources :orders, only: :create
+  resources :orders, only: %i[create]
   root to: 'kudos#index'
   
   namespace :admins do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   
   resources :kudos
   resources :rewards, only: %i[index show]
+  resources :orders, only: :create
   root to: 'kudos#index'
   
   namespace :admins do

--- a/db/migrate/20220611145223_create_orders.rb
+++ b/db/migrate/20220611145223_create_orders.rb
@@ -1,0 +1,10 @@
+class CreateOrders < ActiveRecord::Migration[6.1]
+  def change
+    create_table :orders do |t|
+      t.references :employee, null: false
+      t.references :reward, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_29_185355) do
+ActiveRecord::Schema.define(version: 2022_06_11_145223) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,15 @@ ActiveRecord::Schema.define(version: 2022_05_29_185355) do
     t.index ["company_value_id"], name: "index_kudos_on_company_value_id"
     t.index ["giver_id"], name: "index_kudos_on_giver_id"
     t.index ["reciever_id"], name: "index_kudos_on_reciever_id"
+  end
+
+  create_table "orders", force: :cascade do |t|
+    t.bigint "employee_id", null: false
+    t.bigint "reward_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["employee_id"], name: "index_orders_on_employee_id"
+    t.index ["reward_id"], name: "index_orders_on_reward_id"
   end
 
   create_table "rewards", force: :cascade do |t|

--- a/spec/factories/order_factory.rb
+++ b/spec/factories/order_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :order do
+    reward
+    employee
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  let(:employee) { create(:employee) }
+  let(:expensive_reward) { create(:reward, price: 100) }
+
+  # rubocop:disable RSpec/ImplicitExpect
+  describe 'validations' do
+    it { should belong_to(:employee) }
+    it { should belong_to(:reward) }
+
+    it 'is expected check that employee can afford reward' do
+      order = described_class.new(employee: employee, reward: expensive_reward)
+      expect(order).to be_invalid
+      expect(order.errors).to include('can_not_afford')
+    end
+  end
+  # rubocop:enable RSpec/ImplicitExpect
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -8,12 +8,6 @@ RSpec.describe Order, type: :model do
   describe 'validations' do
     it { should belong_to(:employee) }
     it { should belong_to(:reward) }
-
-    it 'is expected check that employee can afford reward' do
-      order = described_class.new(employee: employee, reward: expensive_reward)
-      expect(order).to be_invalid
-      expect(order.errors).to include('can_not_afford')
-    end
   end
   # rubocop:enable RSpec/ImplicitExpect
 end

--- a/spec/system/employee/earned_points_spec.rb
+++ b/spec/system/employee/earned_points_spec.rb
@@ -1,22 +1,26 @@
 require 'rails_helper'
 
-describe 'Employee earned points', type: :system do
+describe 'Employee earned points', type: :system, js: true do
+  before do
+    sign_in employee
+  end
+
   let(:employee) { create(:employee) }
   let(:reward) { create(:reward, price: 3) }
+  let(:expensive_reward) { create(:reward, price: 100) }
+  let!(:kudo) { create(:kudo, reciever: employee) }
 
   context 'when emplyee is signed in' do
     it 'Navbar displays earned points for employee' do
-      sign_in employee
       visit root_path
-      expect(page).to have_content 'Points: 0'
+      expect(page).to have_content 'Points: 1'
       create(:kudo, reciever: employee)
       visit current_path
-      expect(page).to have_content 'Points: 1'
+      expect(page).to have_content 'Points: 2'
     end
 
     it 'destorying kudo decreases points for employee' do
-      sign_in employee
-      kudo = create(:kudo, reciever: employee)
+      # kudo = create(:kudo, reciever: employee)
       visit root_path
       expect(page).to have_content 'Points: 1'
       kudo.destroy
@@ -25,12 +29,23 @@ describe 'Employee earned points', type: :system do
     end
 
     it 'placing order/claming reward decreases points for employee by reward price' do
-      sign_in employee
       create_list(:kudo, 5, reciever: employee)
       visit reward_path(reward)
-      expect(page).to have_content 'Points: 5'
-      click_on 'CLAIM REWARD!'
-      expect(page).to have_content 'Points: 2'
+      expect(page).to have_content 'Points: 6'
+      accept_confirm do
+        click_on 'CLAIM REWARD!'
+      end
+      expect(page).to have_content 'Points: 3'
+    end
+
+    context 'when employee can not afford reward' do
+      it 'shows warning toast' do
+        visit reward_path(reward)
+        accept_confirm do
+          click_on 'CLAIM REWARD!'
+        end
+        expect(page).to have_content 'You can not afford this reward'
+      end
     end
   end
 end

--- a/spec/system/employee/earned_points_spec.rb
+++ b/spec/system/employee/earned_points_spec.rb
@@ -2,18 +2,35 @@ require 'rails_helper'
 
 describe 'Employee earned points', type: :system do
   let(:employee) { create(:employee) }
+  let(:reward) { create(:reward, price: 3) }
 
   context 'when emplyee is signed in' do
     it 'Navbar displays earned points for employee' do
       sign_in employee
       visit root_path
       expect(page).to have_content 'Points: 0'
-      kudo = create(:kudo, reciever: employee)
+      create(:kudo, reciever: employee)
       visit current_path
+      expect(page).to have_content 'Points: 1'
+    end
+
+    it 'destorying kudo decreases points for employee' do
+      sign_in employee
+      kudo = create(:kudo, reciever: employee)
+      visit root_path
       expect(page).to have_content 'Points: 1'
       kudo.destroy
       visit current_path
       expect(page).to have_content 'Points: 0'
+    end
+
+    it 'placing order/claming reward decreases points for employee by reward price' do
+      sign_in employee
+      create_list(:kudo, 5, reciever: employee)
+      visit reward_path(reward)
+      expect(page).to have_content 'Points: 5'
+      click_on 'CLAIM REWARD!'
+      expect(page).to have_content 'Points: 2'
     end
   end
 end

--- a/spec/system/rewards/show_spec.rb
+++ b/spec/system/rewards/show_spec.rb
@@ -15,10 +15,11 @@ describe 'Reward show action', type: :system do
       expect(page).to have_content(reward.description)
       expect(page).to have_content(reward.price)
     end
-  end
 
-  it 'show Back link' do
-    visit reward_path(reward)
-    expect(page).to have_link('Back')
+    it 'show Back and Claim Reward! links' do
+      visit reward_path(reward)
+      expect(page).to have_link('Back')
+      expect(page).to have_link('CLAIM REWARD!')
+    end
   end
 end


### PR DESCRIPTION
Sprint 4, task 2 

Employee can buy a reward. 

Adds Order model, controller and path.

Changes how points are calculated. Points are now substracted by cost of claimed rewards. 

Add test for Order model validations and points calculation. 

![place-order](https://user-images.githubusercontent.com/22965927/173426814-a86f563c-e93c-4910-98fd-b404e3c8f9ae.gif)
