### PR TITLE
Feature/list of bought rewards

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -4,9 +4,8 @@ class OrdersController < EmployeeBaseController
   end
 
   def create
-    @order = Order.new(reward_id: order_params)
-    order.employee = current_employee
-    order.set_purchase_price
+    reward = Reward.find(order_params[:reward_id])
+    @order = Order.new(reward: reward, employee: current_employee, purchase_price: reward.price)
     if order.save
       redirect_to rewards_path, notice: 'You have bought a reward!'
     else
@@ -18,7 +17,7 @@ class OrdersController < EmployeeBaseController
   private
 
   def order_params
-    params.require(:reward_id)
+    params.permit(:reward_id)
   end
 
   def order

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,11 +1,16 @@
 class OrdersController < EmployeeBaseController
+  def index
+    @orders = Order.where(employee: current_employee).includes(:reward)
+  end
+
   def create
     @order = Order.new(reward_id: order_params)
-    @order.employee = current_employee
-    if @order.save
+    order.employee = current_employee
+    order.set_purchase_price
+    if order.save
       redirect_to rewards_path, notice: 'You have bought a reward!'
     else
-      flash[:alert] = @order.errors[:can_not_afford].join('. ')
+      flash[:alert] = order.errors[:can_not_afford].join('. ')
       redirect_back fallback_location: rewards_path
     end
   end
@@ -13,6 +18,10 @@ class OrdersController < EmployeeBaseController
   private
 
   def order_params
-    params.require(:reward)
+    params.require(:reward_id)
+  end
+
+  def order
+    @order ||= Order.find(params[:order_id])
   end
 end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -13,6 +13,6 @@ class Employee < ApplicationRecord
   has_many :rewards, through: :orders
 
   def points
-    received_kudos.count - rewards.sum(:price)
+    received_kudos.count - orders.sum(:purchase_price)
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -9,8 +9,4 @@ class Order < ApplicationRecord
 
     errors.add(:can_not_afford, 'You can not afford this reward')
   end
-
-  def set_purchase_price
-    self.purchase_price = reward.price
-  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -9,4 +9,8 @@ class Order < ApplicationRecord
 
     errors.add(:can_not_afford, 'You can not afford this reward')
   end
+
+  def set_purchase_price
+    self.purchase_price = reward.price
+  end
 end

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -13,6 +13,7 @@
     <div class="navbar-start">
       <%= link_to 'Kudos', kudos_path, class: 'navbar-item' %>
       <%= link_to 'Rewards', rewards_path, class: 'navbar-item' %>
+      <%= link_to 'Orders', orders_path, class: 'navbar-item' %>
     </div>
 
     <div class="navbar-end">

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,0 +1,23 @@
+<div class='container is-max-widescreen'>
+  <nav class="level is-mobile">
+    <div class="level-left">
+      <p class='is-size-3'><strong>Orders</strong></p>
+    </div>
+  </nav>
+  <div class='box'>
+    <div class="list has-hoverable-list-items has-visible-pointer-controls">
+      <% @orders.each do |order| %>
+        <div class="list-item" test_id="order_<%= order.id %>">
+          <div class="list-item-content">
+            <div class="list-item-title"><%= order.reward.title %></div>
+            <div class="list-item-description">
+              <p class="has-text-weight-semibold">Price: <%= order.purchase_price %></p>
+              <p><%= order.reward.description %></p>
+              <p><%= order.created_at.strftime("%F") %></p>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/rewards/show.html.erb
+++ b/app/views/rewards/show.html.erb
@@ -12,7 +12,7 @@
     </p>
 
     <div class='mt-3'>
-      <%= link_to 'CLAIM REWARD!', orders_path(reward: @reward), method: :post, data: { confirm: 'Are you sure?' }, class: 'button is-primary' %>
+      <%= link_to 'CLAIM REWARD!', orders_path(reward_id: @reward.id), method: :post, data: { confirm: 'Are you sure?' }, class: 'button is-primary' %>
       <%= link_to 'Back', rewards_path, class: 'button' %>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   
   resources :kudos
   resources :rewards, only: %i[index show]
-  resources :orders, only: %i[create]
+  resources :orders, only: %i[index create]
   root to: 'kudos#index'
   
   namespace :admins do

--- a/db/migrate/20220620190549_add_purchase_price_to_order.rb
+++ b/db/migrate/20220620190549_add_purchase_price_to_order.rb
@@ -1,5 +1,16 @@
 class AddPurchasePriceToOrder < ActiveRecord::Migration[6.1]
   def change
-    add_column :orders, :purchase_price, :integer, null: false
+    add_column :orders, :purchase_price, :integer
+    update_orders_current_price_where_not_set
+    change_column_null :orders, :purchase_price, false
+  end
+
+  def update_orders_current_price_where_not_set
+    Order.all.each do |order|
+      if order.purchase_price.nil? 
+        order.purchase_price = order.reward.price
+        order.save
+      end
+    end
   end
 end

--- a/db/migrate/20220620190549_add_purchase_price_to_order.rb
+++ b/db/migrate/20220620190549_add_purchase_price_to_order.rb
@@ -1,0 +1,5 @@
+class AddPurchasePriceToOrder < ActiveRecord::Migration[6.1]
+  def change
+    add_column :orders, :purchase_price, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_11_145223) do
+ActiveRecord::Schema.define(version: 2022_06_20_190549) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -65,6 +65,7 @@ ActiveRecord::Schema.define(version: 2022_06_11_145223) do
     t.bigint "reward_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "purchase_price", null: false
     t.index ["employee_id"], name: "index_orders_on_employee_id"
     t.index ["reward_id"], name: "index_orders_on_reward_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,7 +62,7 @@ ActiveRecord::Schema.define(version: 2022_06_20_190549) do
 
   create_table "orders", force: :cascade do |t|
     t.bigint "employee_id", null: false
-    t.bigint "reward_id", null: false
+    t.bigint "reward_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "purchase_price", null: false

--- a/spec/system/orders/index_spec.rb
+++ b/spec/system/orders/index_spec.rb
@@ -1,19 +1,39 @@
 require 'rails_helper'
 
 describe 'Employee can list bought rewards', type: :system do
+  before do
+    sign_in employee
+    sign_in admin
+    create_list(:kudo, 3, reciever: employee)
+    create_list(:order, 2, employee: employee, purchase_price: reward.price)
+  end
+
+  let!(:admin) { create(:admin) }
   let!(:employee) { create(:employee) }
-  let!(:kudo) { create(:kudo, reciever: employee) }
+  let(:reward) { create(:reward) }
   let(:expensive_reward) { create(:reward, price: 10) }
 
   context 'when employee goes to order list' do
     it 'show all employees orders' do
-      sign_in employee
       visit orders_path
-      # puts page.body
-      order = create(:order, employee: employee)
-      puts order.inspect
-      order.save
-      expect(page).to have_selector(:css, "div[test_id^='order_']", count: 1)
+      expect(page).to have_selector(:css, "div[test_id^='order_']", count: 2)
+      expect(page).to have_content(reward.title, count: 2)
+      expect(page).to have_content(reward.description, count: 2)
+      expect(page).to have_content("Price: #{reward.price}", count: 2)
+      expect(page).to have_content(reward.created_at.strftime('%F'), count: 2)
+    end
+  end
+
+  context 'when admin edits price list' do
+    it 'does not change displayed price' do
+      visit edit_admins_reward_path(reward)
+      old_price = reward.price
+      fill_in 'Price', with: 10
+      click_on 'Save Reward'
+      expect(page).to have_content('Price: 10')
+      visit orders_path
+      expect(page).to have_selector(:css, "div[test_id^='order_']", count: 2)
+      expect(page).to have_content("Price: #{old_price}", count: 2)
     end
   end
 end

--- a/spec/system/orders/index_spec.rb
+++ b/spec/system/orders/index_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe 'Employee can list bought rewards', type: :system do
+  let!(:employee) { create(:employee) }
+  let!(:kudo) { create(:kudo, reciever: employee) }
+  let(:expensive_reward) { create(:reward, price: 10) }
+
+  context 'when employee goes to order list' do
+    it 'show all employees orders' do
+      sign_in employee
+      visit orders_path
+      # puts page.body
+      order = create(:order, employee: employee)
+      puts order.inspect
+      order.save
+      expect(page).to have_selector(:css, "div[test_id^='order_']", count: 1)
+    end
+  end
+end


### PR DESCRIPTION
Sprint 4 / task 3: list-of-bought-rewards

Adds displaying orders to employee.
Changes how order price is kept in DB. Add purchase_price column which stores reward price at time of purchase so it does not change with later edits done by admin.

PR features:

- Migration and schema update
- order controller update
- New route
- New view
- Tests

![list-orders](https://user-images.githubusercontent.com/22965927/175644365-ba73c26a-d9b4-4c0a-84df-759fcad9db4d.gif)
