### PR TITLE
Feature/mark orders as delivered

### DIFF
--- a/app/controllers/admins/kudos_controller.rb
+++ b/app/controllers/admins/kudos_controller.rb
@@ -6,16 +6,9 @@ module Admins
 
     def destroy
       @kudo = Kudo.find(params[:id])
-      authorize!
       @kudo.destroy
       flash[:notice] = 'Kudo was successfully destroyed.'
       redirect_to admins_kudos_path
-    end
-
-    private
-
-    def authorize!
-      raise AuthorizationError unless admin_signed_in?
     end
   end
 end

--- a/app/controllers/admins/orders_controller.rb
+++ b/app/controllers/admins/orders_controller.rb
@@ -5,7 +5,6 @@ module Admins
     end
 
     def deliver
-      authorize!
       order.delivered_status!
       redirect_back fallback_location: admins_orders_path
     end
@@ -14,10 +13,6 @@ module Admins
 
     def order
       @order ||= Order.find(params[:id])
-    end
-
-    def authorize!
-      raise AuthorizationError unless admin_signed_in?
     end
   end
 end

--- a/app/controllers/admins/orders_controller.rb
+++ b/app/controllers/admins/orders_controller.rb
@@ -2,7 +2,6 @@ module Admins
   class OrdersController < BaseController
     def index
       @orders = Order.all.includes(:employee, :reward).order(status: :asc)
-      @undelivered_orders_count = count_undelivered
     end
 
     def deliver
@@ -19,10 +18,6 @@ module Admins
 
     def authorize!
       raise AuthorizationError unless admin_signed_in?
-    end
-
-    def count_undelivered
-      @orders.count { |order| order.status != 'delivered' }
     end
   end
 end

--- a/app/controllers/admins/orders_controller.rb
+++ b/app/controllers/admins/orders_controller.rb
@@ -5,7 +5,7 @@ module Admins
     end
 
     def deliver
-      order.delivered_status!
+      order.delivered!
       redirect_back fallback_location: admins_orders_path
     end
 

--- a/app/helpers/navbar_helper.rb
+++ b/app/helpers/navbar_helper.rb
@@ -22,6 +22,6 @@ module NavbarHelper
   end
 
   def undelivered_orders_count
-    @undelivered_orders_count ||= Order.not_delivered_status.count
+    @undelivered_orders_count ||= Order.not_delivered.count
   end
 end

--- a/app/helpers/navbar_helper.rb
+++ b/app/helpers/navbar_helper.rb
@@ -20,4 +20,8 @@ module NavbarHelper
       "#{user.class.name}: #{user.email}"
     end
   end
+
+  def undelivered_orders_count
+    @undelivered_orders_count ||= Order.not_delivered_status.count
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,7 +1,7 @@
 class Order < ApplicationRecord
   belongs_to :employee
   belongs_to :reward
-  enum status: { placed: 0, delivered: 1 }, _suffix: true
+  enum status: { placed: 0, delivered: 1 }, _suffix: false
 
   validate :can_employee_afford_price, on: :create
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,7 +1,7 @@
 class Order < ApplicationRecord
   belongs_to :employee
   belongs_to :reward
-  enum status: { placed: 'placed', delivered: 'delivered', not_set: 'not_set' }, _suffix: true
+  enum status: { placed: 0, delivered: 1 }, _suffix: true
 
   validate :can_employee_afford_price, on: :create
 

--- a/app/views/admins/orders/index.html.erb
+++ b/app/views/admins/orders/index.html.erb
@@ -19,7 +19,7 @@
           </div>
           <div class="list-item-controls">
             <div class="buttons is-right">
-              <% unless order.delivered_status? %>
+              <% unless order.delivered? %>
                 <%= link_to 'Deliver', deliver_admins_order_path(order), method: :put, data: { confirm: 'This action can not be undone. Do you want to deliver reward?' }, class: "button is-outlined"  %>
               <% else %>
                 <%= link_to 'Delivered', '#', disabled: true, class: "button is-outlined"  %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -51,7 +51,7 @@
             <%= link_to 'Employees', admins_employees_path, class: 'navbar-item' %>
             <%= link_to 'Company Values', admins_company_values_path, class: 'navbar-item' %>
             <%= link_to 'Rewards', admins_rewards_path, class: 'navbar-item' %>
-            <%= link_to "Orders ( #{@undelivered_orders_count} )", admins_orders_path, class: 'navbar-item' %>
+            <%= link_to "Orders ( #{undelivered_orders_count} )", admins_orders_path, class: 'navbar-item' %>
             <hr class="navbar-divider">
             <%= display_curent_users_email_on_test_or_development(current_admin) %>
             <%= link_to 'Sign out Admin', destroy_admin_session_path, method: :delete, class: 'navbar-item' %>

--- a/db/migrate/20220711064604_add_status_to_orders.rb
+++ b/db/migrate/20220711064604_add_status_to_orders.rb
@@ -1,17 +1,6 @@
 class AddStatusToOrders < ActiveRecord::Migration[6.1]
-  def up
-    execute <<-SQL
-      CREATE TYPE order_status AS ENUM ('placed', 'delivered', 'not_set');
-    SQL
-    add_column :orders, :status, :order_status
+  def change
+    add_column :orders, :status, :integer
     add_index :orders, :status
-  end
-
-  def down
-    remove_column :orders, :status
-    remove_index :orders, :status
-    execute <<-SQL
-      DROP TYPE order_status
-    SQL
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,8 +60,17 @@ ActiveRecord::Schema.define(version: 2022_07_11_073501) do
     t.index ["reciever_id"], name: "index_kudos_on_reciever_id"
   end
 
-# Could not dump table "orders" because of following StandardError
-#   Unknown type 'order_status' for column 'status'
+  create_table "orders", force: :cascade do |t|
+    t.bigint "employee_id", null: false
+    t.bigint "reward_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "purchase_price", null: false
+    t.integer "status", null: false
+    t.index ["employee_id"], name: "index_orders_on_employee_id"
+    t.index ["reward_id"], name: "index_orders_on_reward_id"
+    t.index ["status"], name: "index_orders_on_status"
+  end
 
   create_table "rewards", force: :cascade do |t|
     t.string "title", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,25 +1,9 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
-
 Employee.create!([
-  {email: "adam@test.com", password: "adamadam", password_confirmation: "adamadam", number_of_available_kudos: '9'},
-  {email: "tomasz@test.com", password: "tomasztomasz", password_confirmation: "tomasztomasz", number_of_available_kudos: '9'},
-  {email: "test@test.com", password: "testtest", password_confirmation: "testtest", number_of_available_kudos: '9'},
+  {email: "adam@test.com", password: "adamadam", password_confirmation: "adamadam", number_of_available_kudos: '10'},
+  {email: "tomasz@test.com", password: "tomasztomasz", password_confirmation: "tomasztomasz", number_of_available_kudos: '10'},
+  {email: "test@test.com", password: "testtest", password_confirmation: "testtest", number_of_available_kudos: '10'},
   {email: "asd@test.com", password: "asdasd", password_confirmation: "asdasd", number_of_available_kudos: '10'},
   {email: "user@test.com", password: "useruser", password_confirmation: "useruser", number_of_available_kudos: '10'}
-])
-
-["Honesty", "Ownership", "Accountability", "Passion"].each { |cv| CompanyValue.create!(title: cv) }
-
-Kudo.create!([
-  {title: "Kudo 1", content: "Kudo 1 content", giver: Employee.find_by(email: 'adam@test.com'), reciever: Employee.find_by(email: 'tomasz@test.com'), company_value: CompanyValue.find_by(title: 'Passion')},
-  {title: "Kudo 2", content: "Kudo 2 content", giver: Employee.find_by(email: 'test@test.com'), reciever: Employee.find_by(email: 'user@test.com'), company_value: CompanyValue.find_by(title: 'Honesty')},
-  {title: "Kudo 3", content: "Kudo 3 content", giver: Employee.find_by(email: 'tomasz@test.com'), reciever: Employee.find_by(email: 'adam@test.com'), company_value: CompanyValue.find_by(title: 'Honesty')}
 ])
 
 Admin.create!([
@@ -27,6 +11,35 @@ Admin.create!([
   {email: "admin2@test.com", password: "adminadmin", password_confirmation: "adminadmin"}
   ])
 
-(1..6).each do |i|
-  Reward.create(title: "Reward #{i}", description: "Reward #{i} description", price: i)
+%w[Honesty Ownership Accountability Passion].each { |cv| CompanyValue.create!(title: cv) }
+
+company_values = CompanyValue.all
+employees = Employee.all
+employees.each do |employee|
+  recievers = Array.new(employees)
+  recievers.delete(employee)
+  rand(4..8).times do |i|
+    Kudo.create!(title: "Kudo #{i}", content: "Kudo #{i} by #{employee.email} content",
+                  giver: employee, reciever: recievers.sample,
+                  company_value: company_values.sample)
+    employee.decrement(:number_of_available_kudos).save
+  end
+end
+
+Reward.create!([
+  { title: "Bag of Wooden Nickels", description: "The Bag of Wooden Nickels was a bag of wooden coins was one of the many treasures in the treasure hold of LeChuck's ship.", price: 1 },
+  { title: "Bottomless mug", description: "The Bottomless Mug was simply a mug with no bottom.", price: 1 },
+  { title: "Brimstone Beach Club Card", description: "Brimstone Beach Club. Member Since 1632", price: 1 },
+  { title: "Cursed Diamond Ring", description: "The ring, when placed on a persons finger, would turn its wearer gold.", price: 1 },
+  { title: "Pancake Syrup", description: "Pancake Syrup was a sweet treat used as topping for puddings.", price: 1 },
+  { title: "Murray's Arm", description: "The arm wore a floatie which made it float in the water, and grasped a pirate sword.", price: 1 }
+])
+
+rewards = Reward.all
+employees.each do |employee|
+  sample_rewards = rewards.sample(2)
+  Order.create!([
+    {employee: employee, reward: sample_rewards.first, purchase_price: sample_rewards.first.price, status: :placed},
+    {employee: employee, reward: sample_rewards.last, purchase_price: sample_rewards.last.price, status: :delivered}
+  ])
 end

--- a/spec/factories/order_factory.rb
+++ b/spec/factories/order_factory.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :order do
     reward
     employee
+    status { :placed }
   end
 end

--- a/spec/system/admins/orders/deliver_order_spec.rb
+++ b/spec/system/admins/orders/deliver_order_spec.rb
@@ -26,7 +26,7 @@ describe 'Admin can deliver placed orders', type: :system, js: true do
   end
 
   context 'when admin delivers order' do
-    it 'does not change displayed price' do
+    it 'decreases undelivered orders count, marks and sort delivered' do
       visit admins_orders_path
       first_deliver_link = page.first(:link, text: 'Deliver')
       accept_confirm do

--- a/spec/system/admins/orders/deliver_order_spec.rb
+++ b/spec/system/admins/orders/deliver_order_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe 'Admin can deliver placed orders', type: :system, js: true do
+  before do
+    sign_in admin
+    create_list(:kudo, 2, reciever: employee)
+    create_list(:order, 2, employee: employee, purchase_price: reward.price)
+  end
+
+  let!(:admin) { create(:admin) }
+  let!(:employee) { create(:employee) }
+  let(:reward) { create(:reward) }
+  let(:order) { create(:order) }
+
+  context 'when admin goes to orders list' do
+    it 'show all orders' do
+      visit admins_orders_path
+      expect(page).to have_selector('a', text: 'Orders ( 2 )', visible: :all)
+      expect(page).to have_selector(:css, "div[test_id^='order_']", count: 2)
+      expect(page).to have_content(reward.title, count: 2)
+      expect(page).to have_content(reward.description, count: 2)
+      expect(page).to have_content("Price: #{reward.price}", count: 2)
+      expect(page).to have_content(reward.created_at.strftime('%F'), count: 2)
+      expect(page).to have_link('Deliver', count: 2, exact: true)
+    end
+  end
+
+  context 'when admin delivers order' do
+    it 'does not change displayed price' do
+      visit admins_orders_path
+      first_deliver_link = page.first(:link, text: 'Deliver')
+      accept_confirm do
+        click_link 'Deliver', match: :first
+      end
+      expect(first_deliver_link).not_to be(page.first(:link, text: 'Deliver'))
+      expect(page).to have_selector('a', text: 'Orders ( 1 )', visible: :all)
+      expect(page).to have_link('Deliver', count: 1, exact: true)
+      expect(page).to have_link('Delivered', count: 1, exact: true)
+    end
+  end
+end


### PR DESCRIPTION
Sprint 5 / task 1

PR include:
- order status ENUM with index constraint on DB
- new orders have 'placed' status
- view of all orders list in admin panel
- displaying of undelivered orders in admin links panel
- admin can deliver order (changes status enum to 'delivered')
- admin can not deliver order twice
- updated seeds.rb
- tests
![admin-deliver-order](https://user-images.githubusercontent.com/22965927/178438825-1c25e5f2-af16-481f-b2c6-376ff283fec6.gif)


