### PR TITLE
Feature/filter-orders

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,6 +1,8 @@
 class OrdersController < EmployeeBaseController
   def index
     @orders = Order.where(employee: current_employee).includes(:reward)
+    @orders = @orders.delivered if order_params[:query] == 'delivered'
+    @orders = @orders.placed if order_params[:query] == 'not_delivered'
   end
 
   def create
@@ -17,7 +19,7 @@ class OrdersController < EmployeeBaseController
   private
 
   def order_params
-    params.permit(:reward_id)
+    params.permit(:reward_id, :query)
   end
 
   def order

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -19,7 +19,7 @@ class OrdersController < EmployeeBaseController
   private
 
   def order_params
-    params.permit(:reward_id, :query)
+    params.permit(:reward_id, :status)
   end
 
   def order

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,8 +1,8 @@
 class OrdersController < EmployeeBaseController
   def index
     @orders = Order.where(employee: current_employee).includes(:reward)
-    @orders = @orders.delivered if order_params[:query] == 'delivered'
-    @orders = @orders.placed if order_params[:query] == 'not_delivered'
+    @orders = @orders.delivered if order_params[:status] == 'delivered'
+    @orders = @orders.placed if order_params[:status] == 'not_delivered'
   end
 
   def create

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,0 +1,5 @@
+module OrdersHelper
+  def active_if_filter_selected(query)
+    'is-active' if request.params[:query] == query
+  end
+end

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,7 +1,7 @@
 module OrdersHelper
   def active_if_filter_selected(query)
-    if request.params[:query] == query ||
-       (query == 'all' && request.params[:query].nil?)
+    if request.params[:status] == query ||
+       (query == 'all' && request.params[:status].nil?)
       'is-active'
     end
   end

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,5 +1,8 @@
 module OrdersHelper
   def active_if_filter_selected(query)
-    'is-active' if request.params[:query] == query
+    if request.params[:query] == query ||
+       (query == 'all' && request.params[:query].nil?)
+      'is-active'
+    end
   end
 end

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -5,9 +5,9 @@
     </div>
     <div class="tabs is-centered">
       <ul>
-        <li class=<%= active_if_filter_selected('delivered') %>><%= link_to 'delivered', orders_path(query: 'delivered') %></li>
-        <li class=<%= active_if_filter_selected('not_delivered') %>><%= link_to 'not delivered', orders_path(query: 'not_delivered') %></li>
-        <li class=<%= active_if_filter_selected('all') %>><%= link_to 'all', orders_path(query: 'all')%></li>
+        <li class=<%= active_if_filter_selected('delivered') %>><%= link_to 'delivered', orders_path(status: 'delivered') %></li>
+        <li class=<%= active_if_filter_selected('not_delivered') %>><%= link_to 'not delivered', orders_path(status: 'not_delivered') %></li>
+        <li class=<%= active_if_filter_selected('all') %>><%= link_to 'all', orders_path(status: 'all')%></li>
       </ul>
     </div>
   </nav>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -3,6 +3,13 @@
     <div class="level-left">
       <p class='is-size-3'><strong>Orders</strong></p>
     </div>
+    <div class="tabs is-centered">
+      <ul>
+        <li class=<%= active_if_filter_selected('delivered') %>><%= link_to 'delivered', orders_path(query: 'delivered') %></li>
+        <li class=<%= active_if_filter_selected('not_delivered') %>><%= link_to 'not delivered', orders_path(query: 'not_delivered') %></li>
+        <li class=<%= active_if_filter_selected('all') %>><%= link_to 'all', orders_path(query: 'all')%></li>
+      </ul>
+    </div>
   </nav>
   <div class='box'>
     <div class="list has-hoverable-list-items has-visible-pointer-controls">
@@ -13,7 +20,8 @@
             <div class="list-item-description">
               <p class="has-text-weight-semibold">Price: <%= order.purchase_price %></p>
               <p><%= order.reward.description %></p>
-              <p><%= order.created_at.strftime("%F") %></p>
+              <p>Ordered on: <%= order.created_at.strftime("%F") %></p>
+              <p>Status: <%= order.status %></p>
             </div>
           </div>
         </div>

--- a/spec/system/orders/index_spec.rb
+++ b/spec/system/orders/index_spec.rb
@@ -1,11 +1,12 @@
 require 'rails_helper'
 
-describe 'Employee can list bought rewards', type: :system do
+describe 'Employee can list bought rewards', type: :system, js: true do
   before do
     sign_in employee
     sign_in admin
     create_list(:kudo, 3, reciever: employee)
     create_list(:order, 2, employee: employee, purchase_price: reward.price)
+    create_list(:order, 1, employee: employee, purchase_price: reward.price, status: :delivered)
   end
 
   let!(:admin) { create(:admin) }
@@ -14,13 +15,35 @@ describe 'Employee can list bought rewards', type: :system do
   let(:expensive_reward) { create(:reward, price: 10) }
 
   context 'when employee goes to order list' do
-    it 'show all employees orders' do
+    it 'show all employees orders and highlights all' do
       visit orders_path
-      expect(page).to have_selector(:css, "div[test_id^='order_']", count: 2)
-      expect(page).to have_content(reward.title, count: 2)
-      expect(page).to have_content(reward.description, count: 2)
-      expect(page).to have_content("Price: #{reward.price}", count: 2)
-      expect(page).to have_content(reward.created_at.strftime('%F'), count: 2)
+      expect(page).to have_selector(:css, "div[test_id^='order_']", count: 3)
+      expect(page).to have_content(reward.title, count: 3)
+      expect(page).to have_content(reward.description, count: 3)
+      expect(page).to have_content("Price: #{reward.price}", count: 3)
+      expect(page).to have_content(reward.created_at.strftime('%F'), count: 3)
+      expect(page).to have_content('Status: delivered', count: 1)
+      expect(page).to have_content('Status: placed', count: 2)
+      expect(page.find_link('all').ancestor('li')[:class]).to eq('is-active')
+    end
+
+    context 'when employee clicks on filters' do
+      it 'show only filtered orders' do
+        visit orders_path
+        click_on 'delivered'
+        expect(page).to have_selector(:css, "div[test_id^='order_']", count: 1)
+        expect(page).to have_content('Status: delivered', count: 1)
+        expect(page.find_link('delivered').ancestor('li')[:class]).to eq('is-active')
+
+        click_on 'not delivered'
+        expect(page).to have_selector(:css, "div[test_id^='order_']", count: 2)
+        expect(page).to have_content('Status: placed', count: 2)
+        expect(page.find_link('not delivered').ancestor('li')[:class]).to eq('is-active')
+
+        click_on 'all'
+        expect(page).to have_selector(:css, "div[test_id^='order_']", count: 3)
+        expect(page.find_link('all').ancestor('li')[:class]).to eq('is-active')
+      end
     end
   end
 
@@ -32,8 +55,8 @@ describe 'Employee can list bought rewards', type: :system do
       click_on 'Save Reward'
       expect(page).to have_content('Price: 10')
       visit orders_path
-      expect(page).to have_selector(:css, "div[test_id^='order_']", count: 2)
-      expect(page).to have_content("Price: #{old_price}", count: 2)
+      expect(page).to have_selector(:css, "div[test_id^='order_']", count: 3)
+      expect(page).to have_content("Price: #{old_price}", count: 3)
     end
   end
 end


### PR DESCRIPTION
Sprint 5/ task 2
Add filtering to employee's orders index list. 

Filters can be used by pressing 'delivered', 'not delivered', 'all' links on top of list. Default filter after visiing orders page is 'all'.

PR includes:
- changes to orders#index
- links to filters in view
- displaying order's current status on list
- view helper method that add 'is-active' class to filter links
- system specs
![order-filters](https://user-images.githubusercontent.com/22965927/180004027-fa25df38-712f-4c77-bec3-f261a8f9136f.gif)

