### PR TITLE
Refactor/admin-navbar-partial

### DIFF
--- a/app/views/layouts/_admin_panel.html.erb
+++ b/app/views/layouts/_admin_panel.html.erb
@@ -8,7 +8,7 @@
     <%= link_to 'Employees', admins_employees_path, class: 'navbar-item' %>
     <%= link_to 'Company Values', admins_company_values_path, class: 'navbar-item' %>
     <%= link_to 'Rewards', admins_rewards_path, class: 'navbar-item' %>
-    <%= link_to "Orders ( #{undelivered_orders_count} )", admins_orders_path, class: 'navbar-item' %>
+    <%= link_to "Orders ( #{undelivered_orders_count} )", admins_orders_path, class: 'navbar-item', test_id: 'undelivered_orders_count' %>
     <hr class="navbar-divider">
     <%= display_curent_users_email_on_test_or_development(current_admin) %>
     <%= link_to 'Sign out Admin', destroy_admin_session_path, method: :delete, class: 'navbar-item' %>

--- a/app/views/layouts/_admin_panel.html.erb
+++ b/app/views/layouts/_admin_panel.html.erb
@@ -1,0 +1,14 @@
+<div class="navbar-item has-dropdown is-hoverable" test_id="admin_panel">
+  <a class="navbar-link">
+    Admin panel
+  </a>
+  <div class="navbar-dropdown is-right">
+    <%= link_to 'Dashboard', admins_pages_dashboard_path, class: 'navbar-item' %>
+    <%= link_to 'Kudos', admins_kudos_path, class: 'navbar-item' %>
+    <%= link_to 'Employees', admins_employees_path, class: 'navbar-item' %>
+    <%= link_to 'Company Values', admins_company_values_path, class: 'navbar-item' %>
+    <%= link_to 'Rewards', admins_rewards_path, class: 'navbar-item' %>
+    <%= link_to "Orders ( #{undelivered_orders_count} )", admins_orders_path, class: 'navbar-item' %>
+    <hr class="navbar-divider">
+    <%= display_curent_users_email_on_test_or_development(current_admin) %>
+    <%= link_to 'Sign out Admin', destroy_admin_session_path, method: :delete, class: 'navbar-item' %>

--- a/app/views/layouts/_admin_panel.html.erb
+++ b/app/views/layouts/_admin_panel.html.erb
@@ -12,3 +12,5 @@
     <hr class="navbar-divider">
     <%= display_curent_users_email_on_test_or_development(current_admin) %>
     <%= link_to 'Sign out Admin', destroy_admin_session_path, method: :delete, class: 'navbar-item' %>
+  </div>
+</div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -22,7 +22,7 @@
           <%= style_avaible_kudos(current_employee.number_of_available_kudos) %>
         </div>
         <div class=navbar-item">
-          <span class="tag is-large"> 
+          <span class="tag is-large">
             Points: <%= current_employee.points %>
           </span>
         </div>
@@ -41,22 +41,9 @@
         </div>
       </div>
       <% if admin_signed_in? %>
-        <div class="navbar-item has-dropdown is-hoverable">
-          <a class="navbar-link">
-            Admin panel
-          </a>
-          <div class="navbar-dropdown is-right">
-            <%= link_to 'Dashboard', admins_pages_dashboard_path, class: 'navbar-item' %>
-            <%= link_to 'Kudos', admins_kudos_path, class: 'navbar-item' %>
-            <%= link_to 'Employees', admins_employees_path, class: 'navbar-item' %>
-            <%= link_to 'Company Values', admins_company_values_path, class: 'navbar-item' %>
-            <%= link_to 'Rewards', admins_rewards_path, class: 'navbar-item' %>
-            <%= link_to "Orders ( #{undelivered_orders_count} )", admins_orders_path, class: 'navbar-item' %>
-            <hr class="navbar-divider">
-            <%= display_curent_users_email_on_test_or_development(current_admin) %>
-            <%= link_to 'Sign out Admin', destroy_admin_session_path, method: :delete, class: 'navbar-item' %>
-          <% end %>
-        </div>
-      </div>
+        <%= render "layouts/admin_panel" %>
+      <% end %>
     </div>
-  </nav>
+  </div>
+</div>
+</nav>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -45,5 +45,4 @@
       <% end %>
     </div>
   </div>
-</div>
 </nav>

--- a/spec/factories/order_factory.rb
+++ b/spec/factories/order_factory.rb
@@ -4,5 +4,12 @@ FactoryBot.define do
     employee
     status { :placed }
     created_at { Time.zone.at(0) }
+
+    trait :skip_validate do
+      to_create do |instance|
+        instance.purchase_price = 0
+        instance.save(validate: false)
+      end
+    end
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -3,3 +3,6 @@ require 'capybara/rspec'
 require 'webdrivers'
 
 Selenium::WebDriver.logger.ignore(:browser_options)
+Capybara.configure do |config|
+  config.test_id = 'test_id'
+end

--- a/spec/system/admins/admin_panel_spec.rb
+++ b/spec/system/admins/admin_panel_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe 'Admin can see dedicated navbar panel', type: :system do
+  let!(:admin) { create(:admin) }
+  let(:order) { build(:order) }
+
+  context 'when admin is not logged in' do
+    it 'does not show admin panel in navbar' do
+      visit admins_root_path
+      expect(page).not_to have_selector(:css, "div[test_id='admin_panel']")
+    end
+  end
+
+  context 'when admin is logged in' do
+    before { sign_in admin }
+
+    it 'show admin panel in navbar' do
+      visit admins_root_path
+      expect(page).to have_selector(:css, "div[test_id='admin_panel']")
+    end
+
+    it 'shows links in panel dropdown' do
+      visit admins_root_path
+      admin_panel = page.find("div[test_id='admin_panel']").find('.navbar-dropdown')
+      expect(admin_panel).to have_link('Dashboard')
+      expect(admin_panel).to have_link('Kudos')
+      expect(admin_panel).to have_link('Employees')
+      expect(admin_panel).to have_link('Company Values')
+      expect(admin_panel).to have_link('Rewards')
+      expect(admin_panel).to have_link('Orders')
+      expect(admin_panel).to have_link('Sign out Admin')
+    end
+
+    context 'when admin delivers order' do
+      it 'decreases undelivered orders count in navbar' do
+        create_list(:order, 2, :skip_validate)
+        visit admins_orders_path
+        expect { click_link 'Deliver', match: :first }
+          .to change { page.find_link('undelivered_orders_count').text }
+          .from('Orders ( 2 )')
+          .to('Orders ( 1 )')
+      end
+    end
+  end
+end

--- a/spec/system/admins/orders/deliver_order_spec.rb
+++ b/spec/system/admins/orders/deliver_order_spec.rb
@@ -15,7 +15,6 @@ describe 'Admin can deliver placed orders', type: :system do
   context 'when admin goes to orders list' do
     it 'show all orders' do
       visit admins_orders_path
-      expect(page).to have_selector('a', text: 'Orders ( 2 )', visible: :all)
       expect(page).to have_selector(:css, "div[test_id^='order_']", count: 2)
       expect(page).to have_content(reward.title, count: 2)
       expect(page).to have_content(reward.description, count: 2)
@@ -26,12 +25,11 @@ describe 'Admin can deliver placed orders', type: :system do
   end
 
   context 'when admin delivers order' do
-    it 'decreases undelivered orders count, marks and sort delivered' do
+    it 'marks delivered and sort by order_status' do
       visit admins_orders_path
       first_deliver_link = page.first(:link, text: 'Deliver')
       click_link 'Deliver', match: :first
       expect(first_deliver_link).not_to be(page.first(:link, text: 'Deliver'))
-      expect(page).to have_selector('a', text: 'Orders ( 1 )', visible: :all)
       expect(page).to have_link('Deliver', count: 1, exact: true)
       expect(page).to have_link('Delivered', count: 1, exact: true)
     end


### PR DESCRIPTION
splits of admin's navbar panel to partial and add system spec to test that admin panel is properly displayed

Tests:
- if panel is properly hidden when admin is not signed in
- if panel is displayed for admin
- are links present
- if Orders count in link changes with delivery (moved from deliver_order_spec)