### PR TITLE
Feature/timelimited-kudo-edit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,3 +46,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+
+gem "pundit", "~> 2.2"

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'pg', '~> 1.1'
 # Premailer inlines CSS to emails and generates text variants of HTML emails.
 gem 'premailer-rails'
 gem 'puma', '~> 5.0'
+gem 'pundit', '~> 2.2'
 gem 'rails', '~> 6.1.4', '>= 6.1.4.1'
 gem 'sass-rails', '>= 6'
 gem 'webpacker', '~> 5.0'
@@ -46,5 +47,3 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
-
-gem "pundit", "~> 2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,8 @@ GEM
     public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
+    pundit (2.2.0)
+      activesupport (>= 3.0.0)
     racc (1.6.0)
     rack (2.2.3)
     rack-mini-profiler (2.3.4)
@@ -321,6 +323,7 @@ DEPENDENCIES
   premailer-rails
   pry-rails
   puma (~> 5.0)
+  pundit (~> 2.2)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.4, >= 6.1.4.1)
   rspec-rails (~> 5.1, >= 5.1.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  rescue_from 'AuthorizationError', with: :deny_access
+  include Pundit::Authorization
+
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   private
 
-  def deny_access
-    redirect_to root_path, flash: { alert: 'Only givers can modify kudos' }
+  def user_not_authorized
+    flash[:alert] = 'You can not perform this action.'
+    redirect_back(fallback_location: root_path)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,11 @@ class ApplicationController < ActionController::Base
 
   def user_not_authorized
     flash[:alert] = 'You can not perform this action.'
-    redirect_back(fallback_location: root_path)
+    can_be_infinite_redirect = request.url == request.referer
+    if can_be_infinite_redirect
+      redirect_to root_path
+    else
+      redirect_back(fallback_location: root_path)
+    end
   end
 end

--- a/app/controllers/employee_base_controller.rb
+++ b/app/controllers/employee_base_controller.rb
@@ -1,3 +1,6 @@
 class EmployeeBaseController < ApplicationController
   before_action :authenticate_employee!
+  def pundit_user
+    current_employee
+  end
 end

--- a/app/controllers/kudos_controller.rb
+++ b/app/controllers/kudos_controller.rb
@@ -13,7 +13,7 @@ class KudosController < EmployeeBaseController
 
   def edit
     @kudo = find_kudo
-    authorize!
+    authorize @kudo
   end
 
   def create
@@ -34,7 +34,7 @@ class KudosController < EmployeeBaseController
 
   def update
     @kudo = find_kudo
-    authorize!
+    authorize @kudo
     if @kudo.update(kudo_params)
       redirect_to @kudo, notice: 'Kudo was successfully updated.'
     else
@@ -44,7 +44,7 @@ class KudosController < EmployeeBaseController
 
   def destroy
     @kudo = find_kudo
-    authorize!
+    authorize @kudo
     @kudo.destroy
     flash[:notice] = 'Kudo was successfully destroyed.'
     redirect_back fallback_location: kudos_path
@@ -59,9 +59,5 @@ class KudosController < EmployeeBaseController
   # Only allow a list of trusted parameters through.
   def kudo_params
     params.require(:kudo).permit(:title, :content, :giver_id, :reciever_id, :company_value_id)
-  end
-
-  def authorize!
-    raise AuthorizationError unless @kudo.giver == current_employee
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      raise NotImplementedError, "You must define #resolve in #{self.class}"
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
+end

--- a/app/policies/kudo_policy.rb
+++ b/app/policies/kudo_policy.rb
@@ -18,6 +18,6 @@ class KudoPolicy < ApplicationPolicy
   private
 
   def less_then_5_minutes_past_creation?
-    (Time.current - @record.created_at).floor < 60 * 5
+    @record.created_at > 5.minutes.ago
   end
 end

--- a/app/policies/kudo_policy.rb
+++ b/app/policies/kudo_policy.rb
@@ -1,6 +1,6 @@
 class KudoPolicy < ApplicationPolicy
   def update?
-    giver?
+    giver? && less_then_5_minutes_past_creation?
   end
 
   def edit?
@@ -8,10 +8,16 @@ class KudoPolicy < ApplicationPolicy
   end
 
   def destroy?
-    giver?
+    giver? && less_then_5_minutes_past_creation?
   end
 
   def giver?
     @record.giver == @user
+  end
+
+  private
+
+  def less_then_5_minutes_past_creation?
+    (Time.current - @record.created_at).floor < 60 * 5
   end
 end

--- a/app/policies/kudo_policy.rb
+++ b/app/policies/kudo_policy.rb
@@ -1,0 +1,17 @@
+class KudoPolicy < ApplicationPolicy
+  def update?
+    giver?
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    giver?
+  end
+
+  def giver?
+    @record.giver == @user
+  end
+end

--- a/app/views/kudos/index.html.erb
+++ b/app/views/kudos/index.html.erb
@@ -31,9 +31,9 @@
 
           <div class="list-item-controls">
             <div class="buttons is-right">
-              <% if employee_signed_in? && (kudo.giver == current_employee) %>
-                <%= link_to 'Delete', kudo, method: :delete, data: { confirm: 'Are you sure?' }, class: "button is-danger is-light is-outlined" %>
-                <%= link_to 'Edit', edit_kudo_path(kudo), class: 'button' %>
+              <% if policy(kudo).giver? %>
+                <%= link_to 'Delete', kudo, method: :delete, data: { confirm: 'Are you sure?' }, class: "button is-danger is-light is-outlined", :disabled => !policy(kudo).destroy? %>
+                <%= link_to 'Edit', edit_kudo_path(kudo), class: 'button', :disabled => !policy(kudo).edit? %>
               <% else %>
                 <button class="button is-danger is-light is-outlined is-invisible">
                   <span>Destroy</span>

--- a/app/views/kudos/show.html.erb
+++ b/app/views/kudos/show.html.erb
@@ -27,6 +27,7 @@
     <div class='mt-3'>
       <% if policy(@kudo).giver? %>
         <%= link_to 'Edit', edit_kudo_path(@kudo), class: 'button', :disabled => !policy(@kudo).edit? %>
+        <%= link_to 'Delete', @kudo, method: :delete, data: { confirm: 'Are you sure?' }, class: 'button is-danger is-light is-outlined', :disabled => !policy(@kudo).destroy? %>
       <% end %>
       <%= link_to 'Back', kudos_path, class: 'button' %>
     </div>

--- a/app/views/kudos/show.html.erb
+++ b/app/views/kudos/show.html.erb
@@ -25,8 +25,8 @@
       <%= @kudo.reciever.email %>
     </p>
     <div class='mt-3'>
-      <% if employee_signed_in? && (@kudo.giver == current_employee) %>
-        <%= link_to 'Edit', edit_kudo_path(@kudo), class: 'button' %>
+      <% if policy(@kudo).giver? %>
+        <%= link_to 'Edit', edit_kudo_path(@kudo), class: 'button', :disabled => !policy(@kudo).edit? %>
       <% end %>
       <%= link_to 'Back', kudos_path, class: 'button' %>
     </div>

--- a/spec/policies/kudo_policy_spec.rb
+++ b/spec/policies/kudo_policy_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+require 'pundit/rspec'
+
+describe KudoPolicy do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let!(:employee) { build(:employee) }
+  let(:kudo) { build(:kudo, giver: employee) }
+
+  permissions :giver? do
+    it 'grants access if user is kudo\' giver' do
+      expect(described_class).to permit(employee, kudo)
+    end
+  end
+
+  permissions :update?, :edit?, :destroy? do
+    it 'grants access if less then 5 minutes elapsed since kudo\'s creation' do
+      kudo = create(:kudo, giver: employee)
+      puts kudo.inspect
+      travel 3.minutes
+      expect(described_class).to permit(employee, kudo)
+    end
+
+    it 'denies access if less then 5 minutes elapsed since kudo\'s creation' do
+      kudo = create(:kudo, giver: employee)
+      travel 6.minutes
+      expect(described_class).not_to permit(employee, kudo)
+    end
+  end
+end

--- a/spec/policies/kudo_policy_spec.rb
+++ b/spec/policies/kudo_policy_spec.rb
@@ -16,7 +16,6 @@ describe KudoPolicy do
   permissions :update?, :edit?, :destroy? do
     it 'grants access if less then 5 minutes elapsed since kudo\'s creation' do
       kudo = create(:kudo, giver: employee)
-      puts kudo.inspect
       travel 3.minutes
       expect(described_class).to permit(employee, kudo)
     end

--- a/spec/system/kudo/edit_spec.rb
+++ b/spec/system/kudo/edit_spec.rb
@@ -9,8 +9,8 @@ describe 'Kudo.edit', type: :system, js: true do
   let(:kudo) { create(:kudo) }
 
   context 'when logged in' do
-    context 'when pressing New Kudo link' do
-      it 'shows new kudo form' do
+    context 'when pressing Edit Kudo link' do
+      it 'shows Edit kudo form' do
         logged_employee = create(:employee)
         sign_in logged_employee
         owned_kudo = create(:kudo, giver: logged_employee)

--- a/spec/system/kudo/edit_spec.rb
+++ b/spec/system/kudo/edit_spec.rb
@@ -44,7 +44,8 @@ describe 'Kudo.edit', type: :system, js: true do
         logged_employee = create(:employee)
         sign_in logged_employee
         owned_kudo = create(:kudo, giver: logged_employee)
-        visit edit_kudo_path(owned_kudo)
+        visit root_path
+        click_on 'Edit'
         fill_in 'kudo_title', with: 'Lorem ipsum dolor sit amet'
         fill_in 'kudo_content', with: 'consectetur adipiscing elit. Sed dignissim dignissim urna vel ultrices.'
         last_option_reciever = page.find_field('Reciever').all('option').last.text

--- a/spec/system/kudo/edit_spec.rb
+++ b/spec/system/kudo/edit_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 describe 'Kudo.edit', type: :system, js: true do
+  include ActiveSupport::Testing::TimeHelpers
   before do
     create(:employee)
   end
@@ -37,6 +38,24 @@ describe 'Kudo.edit', type: :system, js: true do
         expect(page).to have_current_path kudo_path(owned_kudo)
         expect(page).to have_content 'Lorem ipsum dolor sit amet'
         expect(page).to have_content 'consectetur adipiscing elit. Sed dignissim dignissim urna vel ultrices.'
+      end
+
+      it 'fails after 5 minutes from kudo\'s creation' do
+        logged_employee = create(:employee)
+        sign_in logged_employee
+        owned_kudo = create(:kudo, giver: logged_employee)
+        visit edit_kudo_path(owned_kudo)
+        fill_in 'kudo_title', with: 'Lorem ipsum dolor sit amet'
+        fill_in 'kudo_content', with: 'consectetur adipiscing elit. Sed dignissim dignissim urna vel ultrices.'
+        last_option_reciever = page.find_field('Reciever').all('option').last.text
+        page.select last_option_reciever, from: 'kudo_reciever_id'
+        last_option_company_value = page.find_field('Company value').all('option').last.text
+        page.select last_option_company_value, from: 'kudo_company_value_id'
+        travel 6.minutes
+        click_on 'Save Kudo'
+        expect(page).to have_current_path root_path
+        expect(page).to have_content owned_kudo.title
+        expect(page).to have_content 'You can not perform this action.'
       end
     end
 

--- a/spec/system/kudo/index_spec.rb
+++ b/spec/system/kudo/index_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 describe 'Kudo.index', type: :system, js: true do
+  include ActiveSupport::Testing::TimeHelpers
   let(:employee) { create(:employee) }
 
   context 'when employee is logged' do
@@ -36,6 +37,28 @@ describe 'Kudo.index', type: :system, js: true do
         within "div[test_id='kudo_#{owned_kudo.id}']" do
           expect(page).to have_content('Delete')
         end
+      end
+
+      it 'after 5 minutes past kudo\'s creation edit, delete links show error and redirects back' do
+        create(:kudo)
+        current_employee = create(:employee)
+        sign_in current_employee
+        owned_kudo = create(:kudo, giver: current_employee)
+        visit root_path
+        travel 5.minutes
+        travel 1.second
+        within "div[test_id='kudo_#{owned_kudo.id}']" do
+          click_on 'Edit'
+        end
+        expect(page).to have_current_path root_path
+        expect(page).to have_content 'You can not perform this action.'
+        within "div[test_id='kudo_#{owned_kudo.id}']" do
+          accept_confirm do
+            click_on 'Delete'
+          end
+        end
+        expect(page).to have_current_path root_path
+        expect(page).to have_content 'You can not perform this action.'
       end
     end
 

--- a/spec/system/kudo/show_spec.rb
+++ b/spec/system/kudo/show_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe 'Kudo\'s show action', type: :system, js: true do
+  include ActiveSupport::Testing::TimeHelpers
+
+  before { sign_in current_employee }
+
+  let!(:current_employee) { create(:employee) }
+  let!(:owned_kudo) { create(:kudo, giver: current_employee) }
+  let!(:not_owned_kudo) { create(:kudo) }
+
+  context 'when employee is logged in' do
+    it 'display owned kudo' do
+      visit kudo_path(owned_kudo)
+      expect(page).to have_content(owned_kudo.title)
+      expect(page).to have_link('Edit')
+      expect(page).to have_link('Delete')
+      expect(page).to have_link('Back')
+    end
+
+    it 'display not owned kudo without edit, delete links' do
+      visit kudo_path(not_owned_kudo)
+      expect(page).to have_content(not_owned_kudo.title)
+      expect(page).to have_no_link('Edit')
+      expect(page).to have_no_link('Delete')
+      expect(page).to have_link('Back')
+    end
+
+    it 'after 5 minutes past kudo\'s creation edit, delete links show error and redirects back' do
+      visit kudo_path(owned_kudo)
+      travel 5.minutes
+      travel 1.second
+      click_on 'Edit'
+      expect(page).to have_current_path kudo_path(owned_kudo)
+      expect(page).to have_content 'You can not perform this action.'
+      accept_confirm do
+        click_on 'Delete'
+      end
+      expect(page).to have_current_path kudo_path(owned_kudo)
+      expect(page).to have_content 'You can not perform this action.'
+    end
+  end
+end


### PR DESCRIPTION
Sprint 6 / task 1: kudo-can-only-be-edited-or-removed-for-5-minutes

PR introduces pundit gem, removes custom authorization of editing and deleting posts with pundit. 
Add 5 minute time limit on kudos edit? destroy? policies. Uses pundit policies in views instead of custom logic.
Unit and system specs for pundit policies are included. 

