### PR TITLE
Feature/pagination for rewards

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 gem 'bulma_form_builder'
 gem 'bulma-rails', '~> 0.9.3'
 gem 'devise', '~> 4.8', '>= 4.8.1'
+gem 'kaminari', '~> 1.2', '>= 1.2.2'
 # Missing dependency on Mailer gem in Ruby 3.1.0
 gem 'net-imap', require: false
 gem 'net-pop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,18 @@ GEM
     htmlentities (4.3.4)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     launchy (2.5.0)
       addressable (~> 2.7)
     letter_opener (1.8.1)
@@ -314,6 +326,7 @@ DEPENDENCIES
   database_cleaner-active_record (~> 2.0, >= 2.0.1)
   devise (~> 4.8, >= 4.8.1)
   factory_bot_rails (~> 6.2)
+  kaminari (~> 1.2, >= 1.2.2)
   letter_opener
   listen (~> 3.3)
   net-imap

--- a/app/controllers/rewards_controller.rb
+++ b/app/controllers/rewards_controller.rb
@@ -1,6 +1,6 @@
 class RewardsController < EmployeeBaseController
   def index
-    @rewards = Reward.all
+    @rewards = Reward.page(params[:page])
   end
 
   def show

--- a/app/models/reward.rb
+++ b/app/models/reward.rb
@@ -1,4 +1,6 @@
 class Reward < ApplicationRecord
   validates :title, :description, :price, presence: true
   validates :price, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
+
+  paginates_per 3
 end

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,17 @@
+<%
+=begin
+
+Link to the "First" page
+- available local variables
+  url          : url to the first page
+  current_page : a page object for the currently displayed page
+  total_pages  : total number of pages
+  per_page     : number of items to fetch per page
+  remote       : data-remote
+
+=end
+%>
+
+<li>
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, class: "pagination-link#{' is-current' if current_page.first?}" %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,17 @@
+<%
+=begin
+
+Non-link tag that stands for skipped pages...
+- available local variables
+  current_page : a page object for the currently displayed page
+  total_pages  : total number of pages
+  per_page     : number of items to fetch per page
+  remote       : data-remote
+
+=end
+%>
+<li>
+  <span class="pagination-ellipsis">
+    <%= t('views.pagination.truncate').html_safe %>
+  </span>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,17 @@
+<%
+=begin
+
+Link to the "Last" page
+- available local variables
+  url          : url to the last page
+  current_page : a page object for the currently displayed page
+  total_pages  : total number of pages
+  per_page     : number of items to fetch per page
+  remote       : data-remote
+
+=end
+%>
+
+<li>
+  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, class: "pagination-link#{' is-current' if current_page.last?}" %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,15 @@
+<%
+=begin
+
+Link to the "Next" page
+- available local variables
+  url          : url to the next page
+  current_page : a page object for the currently displayed page
+  total_pages  : total number of pages
+  per_page     : number of items to fetch per page
+  remote       : data-remote
+
+=end
+%>
+
+<%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote, class: 'pagination-next' %>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,18 @@
+<%
+=begin
+
+Link showing page number
+- available local variables
+  page         : a page object for "this" page
+  url          : url to this page
+  current_page : a page object for the currently displayed page
+  total_pages  : total number of pages
+  per_page     : number of items to fetch per page
+  remote       : data-remote
+
+=end
+%>
+
+<li>
+  <%= link_to page, url, {remote: remote, rel: page.rel, class: "pagination-link#{' is-current' if page.current?}"} %>
+</li>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,31 @@
+<%
+=begin
+
+The container tag
+- available local variables
+  current_page : a page object for the currently displayed page
+  total_pages  : total number of pages
+  per_page     : number of items to fetch per page
+  remote       : data-remote
+  paginator    : the paginator that renders the pagination tags inside
+
+=end
+%>
+
+<%= paginator.render do %>
+  <nav class="pagination">
+    <%= prev_page_tag unless current_page.first? %>
+    <%= next_page_tag unless current_page.last? %>
+    <ul class="pagination-list">
+      <%= first_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.display_tag? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? %>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,15 @@
+<%
+=begin
+
+Link to the "Previous" page
+- available local variables
+  url          : url to the previous page
+  current_page : a page object for the currently displayed page
+  total_pages  : total number of pages
+  per_page     : number of items to fetch per page
+  remote       : data-remote
+
+=end
+%>
+
+<%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote, class: 'pagination-previous' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
 
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= yield :head %>
   </head>
 
   <body>

--- a/app/views/rewards/index.html.erb
+++ b/app/views/rewards/index.html.erb
@@ -4,9 +4,9 @@
       <p class='is-size-3'><strong>Rewards</strong></p>
     </div>
   </nav>
-  <div class="columns is-multiline" style="@include constant-height-card">
+  <div class="columns">
     <% @rewards.each do |reward| %>
-      <div class="column is-one-quarter">
+      <div class="column is-one-third">
         <div class="card constant-height-card" test_id="reward_<%=reward.id%>">
           <div class="card-content constant-height-card">
             <p class="title">
@@ -27,4 +27,5 @@
       </div>
     <% end %>
   </div>
+<%= paginate @rewards %>
 </div>

--- a/app/views/rewards/index.html.erb
+++ b/app/views/rewards/index.html.erb
@@ -29,3 +29,6 @@
   </div>
 <%= paginate @rewards %>
 </div>
+<% content_for :head do %>
+  <%= rel_next_prev_link_tags @rewards %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,13 @@
 Rails.application.routes.draw do
   devise_for :admins, path: 'admins', controllers: { sessions: 'admins/sessions' }, path_names: { sign_in: "" }
   devise_for :employees
+
+  concern :paginatable do
+    get '(page/:page)', action: :index, on: :collection, as: ''
+  end
   
   resources :kudos
-  resources :rewards, only: %i[index show]
+  resources :rewards, only: %i[index show], concerns: :paginatable
   resources :orders, only: %i[index create]
   root to: 'kudos#index'
   

--- a/spec/system/rewards/index_spec.rb
+++ b/spec/system/rewards/index_spec.rb
@@ -1,23 +1,72 @@
 require 'rails_helper'
 
-describe 'Rewards index display all rewards', type: :system do
-  before do
-    sign_in employee
-  end
-
+describe 'Rewards index display paginated rewards', type: :system do
+  let!(:rewards) { create_list(:reward, 7) }
   let(:employee) { create(:employee) }
 
-  context 'when employee is on rewards index page' do
-    it 'shows all rewards' do
-      create_list(:reward, 3)
-      visit rewards_path
+  before do
+    sign_in employee
+    visit root_path
+    click_on 'Rewards'
+  end
+
+  context 'when on rewards index page' do
+    it 'shows rewards ids: 1, 2, 3' do
       expect(page).to have_selector(:css, "div[test_id^='reward_']", count: 3)
+      expect(page).to have_selector(:css, "div[test_id^='reward_#{rewards[0].id}']")
+      expect(page).to have_selector(:css, "div[test_id^='reward_#{rewards[1].id}']")
+      expect(page).to have_selector(:css, "div[test_id^='reward_#{rewards[2].id}']")
+    end
+
+    it 'shows Details link' do
+      expect(page).to have_link('Show details', count: 3)
+    end
+
+    it 'shows pagination links' do
+      expect(page).to have_css('nav.pagination')
+      expect(page).to have_css('a.pagination-link', count: 4)
+      expect(page).to have_link('Last »')
+      expect(page).not_to have_link('« First')
+      expect(page).to have_link('Next ›')
+      expect(page).not_to have_link('‹ Prev')
     end
   end
 
-  it 'shows Details link' do
-    create(:reward)
-    visit rewards_path
-    expect(page).to have_link('Show details')
+  context 'when on rewards 2nd page' do
+    before { click_link '2' }
+
+    it 'shows rewards ids: 4, 5, 6' do
+      expect(page).to have_selector(:css, "div[test_id^='reward_']", count: 3)
+      expect(page).to have_selector(:css, "div[test_id^='reward_#{rewards[3].id}']")
+      expect(page).to have_selector(:css, "div[test_id^='reward_#{rewards[4].id}']")
+      expect(page).to have_selector(:css, "div[test_id^='reward_#{rewards[5].id}']")
+    end
+
+    it 'shows pagination links' do
+      expect(page).to have_css('nav.pagination')
+      expect(page).to have_css('a.pagination-link', count: 5)
+      expect(page).to have_link('Last »')
+      expect(page).to have_link('« First')
+      expect(page).to have_link('Next ›')
+      expect(page).to have_link('‹ Prev')
+    end
+  end
+
+  context 'when on rewards 3nd (final) page' do
+    before { click_link '3' }
+
+    it 'shows reward id: 7' do
+      expect(page).to have_selector(:css, "div[test_id^='reward_']", count: 1)
+      expect(page).to have_selector(:css, "div[test_id^='reward_#{rewards[6].id}']")
+    end
+
+    it 'shows pagination links' do
+      expect(page).to have_css('nav.pagination')
+      expect(page).to have_css('a.pagination-link', count: 4)
+      expect(page).not_to have_link('Last »')
+      expect(page).to have_link('« First')
+      expect(page).not_to have_link('Next ›')
+      expect(page).to have_link('‹ Prev')
+    end
   end
 end


### PR DESCRIPTION
Sprint 6 / task 2: Pagination for rewards

Add pagination to rewards. Show 3 rewards per page.

PR features:

- kaminari gem with bulma styled pagination links
- changes to Rewards model and controller
- adjust rewards index view (use 1/3 columns width, remove multi line column wrapping)
- system specs
- SEO friendly links and head link tags for pagination

![rewards-pagination](https://user-images.githubusercontent.com/22965927/183768949-70a5c9a4-edb1-4cdf-9113-dd45fbfad9f2.gif)
