### PR TITLE
Feature/filter rewards by categories

### DIFF
--- a/app/controllers/rewards_controller.rb
+++ b/app/controllers/rewards_controller.rb
@@ -1,9 +1,21 @@
 class RewardsController < EmployeeBaseController
   def index
-    @rewards = Reward.page(params[:page])
+    @rewards = if reward_params.key?('category')
+                 Reward.includes(:categories).where("categories.title = '#{reward_params[:category]}'").references(:categories)
+               else
+                 Reward.all
+               end
+    @rewards = @rewards.page(params[:page])
+    @categories = Category.pluck(:title)
   end
 
   def show
     @reward = Reward.find(params[:id])
+  end
+
+  private
+
+  def reward_params
+    params.permit(:category)
   end
 end

--- a/app/controllers/rewards_controller.rb
+++ b/app/controllers/rewards_controller.rb
@@ -8,7 +8,7 @@ class RewardsController < EmployeeBaseController
                  Reward.all.includes(:categories)
                end
     @rewards = @rewards.page(params[:page])
-    @categories = Category.pluck(:title)
+    @category_titles = Category.pluck(:title)
   end
 
   def show

--- a/app/controllers/rewards_controller.rb
+++ b/app/controllers/rewards_controller.rb
@@ -16,6 +16,6 @@ class RewardsController < EmployeeBaseController
   private
 
   def reward_params
-    params.permit(:category)
+    params.permit(:category, :page)
   end
 end

--- a/app/controllers/rewards_controller.rb
+++ b/app/controllers/rewards_controller.rb
@@ -1,7 +1,9 @@
 class RewardsController < EmployeeBaseController
   def index
     @rewards = if reward_params.key?('category')
-                 Reward.includes(:categories).where("categories.title = '#{reward_params[:category]}'").references(:categories)
+                 Reward.includes(:categories)
+                       .where("categories.title = '#{reward_params[:category]}'")
+                       .references(:categories)
                else
                  Reward.all.includes(:categories)
                end

--- a/app/controllers/rewards_controller.rb
+++ b/app/controllers/rewards_controller.rb
@@ -1,13 +1,7 @@
 class RewardsController < EmployeeBaseController
   def index
-    @rewards = if reward_params.key?('category')
-                 Reward.includes(:categories)
-                       .where("categories.title = '#{reward_params[:category]}'")
-                       .references(:categories)
-               else
-                 Reward.all.includes(:categories)
-               end
-    @rewards = @rewards.page(params[:page])
+    @rewards = FilterPaginatedRewards.call(category: reward_params[:category],
+                                           page: reward_params[:page])
     @category_titles = Category.pluck(:title)
   end
 

--- a/app/controllers/rewards_controller.rb
+++ b/app/controllers/rewards_controller.rb
@@ -3,7 +3,7 @@ class RewardsController < EmployeeBaseController
     @rewards = if reward_params.key?('category')
                  Reward.includes(:categories).where("categories.title = '#{reward_params[:category]}'").references(:categories)
                else
-                 Reward.all
+                 Reward.all.includes(:categories)
                end
     @rewards = @rewards.page(params[:page])
     @categories = Category.pluck(:title)

--- a/app/presenters/filter_links_presenter.rb
+++ b/app/presenters/filter_links_presenter.rb
@@ -1,0 +1,16 @@
+class FilterLinksPresenter
+  def initialize(view, filter_key)
+    @view = view
+    @filter_key = filter_key
+  end
+
+  def styled_link_to_filter_query(request, filter_argument)
+    @view.content_tag :li, class: conditional_active(request.params, filter_argument) do
+      @view.link_to filter_argument, "#{request.path}?#{@filter_key}=#{filter_argument}"
+    end
+  end
+
+  def conditional_active(request_params, filter_argument)
+    'is-active' if request_params.fetch(@filter_key, '') == filter_argument
+  end
+end

--- a/app/presenters/filter_links_presenter.rb
+++ b/app/presenters/filter_links_presenter.rb
@@ -1,16 +1,27 @@
 class FilterLinksPresenter
-  def initialize(view, filter_key)
+  def initialize(view, filter_key:, default_selected_link: '')
     @view = view
     @filter_key = filter_key
+    @default_selected_link = default_selected_link
   end
 
   def styled_link_to_filter_query(request, filter_argument)
-    @view.content_tag :li, class: conditional_active(request.params, filter_argument) do
-      @view.link_to filter_argument, "#{request.path}?#{@filter_key}=#{filter_argument}"
+    link_selected = link_selected?(request.params, filter_argument)
+    @view.content_tag :li, class: active_class(link_selected) do
+      if link_selected
+        @view.link_to filter_argument, request.path
+      else
+        @view.link_to filter_argument, "#{request.path}?#{@filter_key}=#{filter_argument}"
+      end
     end
   end
 
-  def conditional_active(request_params, filter_argument)
-    'is-active' if request_params.fetch(@filter_key, '') == filter_argument
+  def link_selected?(request_params, filter_argument)
+    request_params.fetch(@filter_key, '') == filter_argument ||
+      (filter_argument == @default_selected_link && !request_params.key?(@filter_key))
+  end
+
+  def active_class(link_selected)
+    'is-active' if link_selected
   end
 end

--- a/app/presenters/filter_links_presenter.rb
+++ b/app/presenters/filter_links_presenter.rb
@@ -9,9 +9,9 @@ class FilterLinksPresenter
     link_selected = link_selected?(request.params, filter_argument)
     @view.content_tag :li, class: active_class(link_selected) do
       if link_selected
-        @view.link_to filter_argument, request.path
+        @view.link_to filter_argument, request.parameters[:controller]
       else
-        @view.link_to filter_argument, "#{request.path}?#{@filter_key}=#{filter_argument}"
+        @view.link_to filter_argument, "#{request.parameters[:controller]}?#{@filter_key}=#{filter_argument}"
       end
     end
   end

--- a/app/presenters/filter_links_presenter.rb
+++ b/app/presenters/filter_links_presenter.rb
@@ -9,9 +9,9 @@ class FilterLinksPresenter
     link_selected = link_selected?(request.params, filter_argument)
     @view.content_tag :li, class: active_class(link_selected) do
       if link_selected
-        @view.link_to filter_argument, request.parameters[:controller]
+        @view.link_to filter_argument, controller: request.parameters[:controller], action: 'index'
       else
-        @view.link_to filter_argument, "#{request.parameters[:controller]}?#{@filter_key}=#{filter_argument}"
+        @view.link_to filter_argument, controller: request.parameters[:controller], action: 'index', @filter_key => filter_argument
       end
     end
   end

--- a/app/presenters/filter_links_presenter.rb
+++ b/app/presenters/filter_links_presenter.rb
@@ -11,7 +11,8 @@ class FilterLinksPresenter
       if link_selected
         @view.link_to filter_argument, controller: request.parameters[:controller], action: 'index'
       else
-        @view.link_to filter_argument, controller: request.parameters[:controller], action: 'index', @filter_key => filter_argument
+        @view.link_to filter_argument, controller: request.parameters[:controller], action: 'index',
+                                       @filter_key => filter_argument
       end
     end
   end

--- a/app/presenters/filter_links_presenter.rb
+++ b/app/presenters/filter_links_presenter.rb
@@ -7,7 +7,7 @@ class FilterLinksPresenter
 
   def styled_link_to_filter_query(request, filter_argument)
     link_selected = link_selected?(request.params, filter_argument)
-    @view.content_tag :li, class: active_class(link_selected) do
+    @view.content_tag :li, class: { 'is-active': link_selected } do
       if link_selected
         @view.link_to filter_argument, controller: request.parameters[:controller], action: 'index'
       else
@@ -20,9 +20,5 @@ class FilterLinksPresenter
   def link_selected?(request_params, filter_argument)
     request_params.fetch(@filter_key, '') == filter_argument ||
       (filter_argument == @default_selected_link && !request_params.key?(@filter_key))
-  end
-
-  def active_class(link_selected)
-    'is-active' if link_selected
   end
 end

--- a/app/queries/filter_paginated_rewards.rb
+++ b/app/queries/filter_paginated_rewards.rb
@@ -1,0 +1,18 @@
+class FilterPaginatedRewards
+  module Scopes
+    def by_category(category)
+      return self if category.blank?
+
+      where("categories.title = '#{category}'")
+        .references(:categories)
+    end
+  end
+
+  def self.call(filters)
+    Reward
+      .includes(:categories)
+      .extending(Scopes)
+      .by_category(filters[:category])
+      .page(filters[:page])
+  end
+end

--- a/app/views/rewards/index.html.erb
+++ b/app/views/rewards/index.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class="tabs is-centered">
       <ul>
-      <% presenter = FilterLinksPresenter.new(self, filter_key: "category") %>
+        <% presenter = FilterLinksPresenter.new(self, filter_key: "category") %>
         <% @categories.each do |category| %>
           <%= presenter.styled_link_to_filter_query(request, category) %>
         <% end %>
@@ -23,6 +23,11 @@
             <p class="subtitle">
               Price: <%= reward.price %>
             </p>
+            <div>
+              <% reward.categories.each do |category| %>
+                <span class='tag'> <%= category.title %></span>
+              <% end %>
+            </div>
           </div>
           <footer class="card-footer">
             <p class="card-footer-item">
@@ -35,7 +40,7 @@
       </div>
     <% end %>
   </div>
-<%= paginate @rewards %>
+  <%= paginate @rewards %>
 </div>
 <% content_for :head do %>
   <%= rel_next_prev_link_tags @rewards %>

--- a/app/views/rewards/index.html.erb
+++ b/app/views/rewards/index.html.erb
@@ -3,6 +3,14 @@
     <div class="level-left">
       <p class='is-size-3'><strong>Rewards</strong></p>
     </div>
+    <div class="tabs is-centered">
+      <ul>
+      <% presenter = FilterLinksPresenter.new(self, filter_key: "category") %>
+        <% @categories.each do |category| %>
+          <%= presenter.styled_link_to_filter_query(request, category) %>
+        <% end %>
+      </ul>
+    </div>
   </nav>
   <div class="columns">
     <% @rewards.each do |reward| %>

--- a/app/views/rewards/index.html.erb
+++ b/app/views/rewards/index.html.erb
@@ -6,7 +6,7 @@
     <div class="tabs is-centered">
       <ul>
         <% presenter = FilterLinksPresenter.new(self, filter_key: "category") %>
-        <% @categories.each do |category| %>
+        <% @category_titles.each do |category| %>
           <%= presenter.styled_link_to_filter_query(request, category) %>
         <% end %>
       </ul>

--- a/spec/system/rewards/index_filtering_spec.rb
+++ b/spec/system/rewards/index_filtering_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Rewards index display filtered rewards', type: :system, js: true do
+describe 'Rewards index display filtered rewards', type: :system do
   let!(:category_with_one_reward) { create(:category_with_rewards, rewards_count: 1) }
   let!(:category_with_nine_rewards) { create(:category_with_rewards, rewards_count: 9) }
   let(:employee) { create(:employee) }

--- a/spec/system/rewards/index_filtering_spec.rb
+++ b/spec/system/rewards/index_filtering_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+describe 'Rewards index display filtered rewards', type: :system, js: true do
+  let!(:category_with_one_reward) { create(:category_with_rewards, rewards_count: 1) }
+  let!(:category_with_nine_rewards) { create(:category_with_rewards, rewards_count: 9) }
+  let(:employee) { create(:employee) }
+
+  before do
+    sign_in employee
+    visit root_path
+    click_on 'Rewards'
+  end
+
+  context 'when on rewards index page' do
+    it 'shows filter links' do
+      expect(page).to have_link(category_with_nine_rewards.title)
+      expect(page).to have_link(category_with_one_reward.title)
+    end
+
+    it 'shows pagination for 4 pages / 10 rewards' do
+      expect(page).to have_link('1')
+      expect(page).to have_link('2')
+      expect(page).to have_link('3')
+      expect(page).to have_link('4')
+    end
+  end
+
+  context 'when filtering by category with one reward' do
+    before { click_link category_with_one_reward.title }
+
+    it 'shows one reward' do
+      expect(page).to have_selector(:css, "div[test_id^='reward_#{category_with_one_reward.rewards.first.id}']")
+    end
+
+    it 'does not show pagination links' do
+      expect(page).not_to have_css('nav.pagination')
+      expect(page).not_to have_css('a.pagination-link', count: 5)
+      expect(page).not_to have_link('Last »')
+      expect(page).not_to have_link('« First')
+      expect(page).not_to have_link('Next ›')
+      expect(page).not_to have_link('‹ Prev')
+    end
+
+    it 'resets filtering when clicking on active filter link' do
+      click_link category_with_one_reward.title
+      expect(page).to have_link('1')
+      expect(page).to have_link('2')
+      expect(page).to have_link('3')
+      expect(page).to have_link('4')
+    end
+  end
+
+  context 'when filtering by category with nine rewards' do
+    before { click_link category_with_nine_rewards.title }
+
+    it 'shows three reward on page' do
+      expect(page).to have_selector(:css, "div[test_id^='reward_']", count: 3)
+      expect(page).to have_selector(:css, "div[test_id^='reward_#{category_with_nine_rewards.rewards.first.id}']")
+      expect(page).to have_selector(:css, "div[test_id^='reward_#{category_with_nine_rewards.rewards.second.id}']")
+      expect(page).to have_selector(:css, "div[test_id^='reward_#{category_with_nine_rewards.rewards.third.id}']")
+    end
+
+    it 'shows pagination links' do
+      expect(page).to have_css('nav.pagination')
+      expect(page).to have_css('a.pagination-link', count: 4)
+      expect(page).to have_link('Last »')
+      expect(page).not_to have_link('« First')
+      expect(page).to have_link('Next ›')
+      expect(page).not_to have_link('‹ Prev')
+    end
+
+    it 'clicking pagination link does not change category' do
+      click_link 'Next'
+      expect(page.find_link(category_with_nine_rewards.title).ancestor('li')[:class]).to eq('is-active')
+    end
+  end
+end

--- a/spec/system/rewards/index_spec.rb
+++ b/spec/system/rewards/index_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Rewards index display paginated rewards', type: :system, js: true do
+describe 'Rewards index display paginated rewards', type: :system do
   let!(:rewards) { create_list(:reward, 7) }
   let(:employee) { create(:employee) }
 

--- a/spec/system/rewards/index_spec.rb
+++ b/spec/system/rewards/index_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Rewards index display paginated rewards', type: :system do
+describe 'Rewards index display paginated rewards', type: :system, js: true do
   let!(:rewards) { create_list(:reward, 7) }
   let(:employee) { create(:employee) }
 
@@ -33,7 +33,11 @@ describe 'Rewards index display paginated rewards', type: :system do
   end
 
   context 'when on rewards 2nd page' do
-    before { click_link '2' }
+    before do
+      within(page.find('nav.pagination')) do
+        click_link '2'
+      end
+    end
 
     it 'shows rewards ids: 4, 5, 6' do
       expect(page).to have_selector(:css, "div[test_id^='reward_']", count: 3)
@@ -53,7 +57,11 @@ describe 'Rewards index display paginated rewards', type: :system do
   end
 
   context 'when on rewards 3nd (final) page' do
-    before { click_link '3' }
+    before do
+      within(page.find('nav.pagination')) do
+        click_link '3'
+      end
+    end
 
     it 'shows reward id: 7' do
       expect(page).to have_selector(:css, "div[test_id^='reward_']", count: 1)


### PR DESCRIPTION
**Sprint 6 / task 4 Filter rewards by categories**

PR includes:
- changes to RewardsController to filter rewards by categories
- links to filtering on rewards index page
- category tags on rewards index
- Presenter class that generates links for filter navbar
- specs for filtering while paginating rewards

**FilterLinksPresenter**
- Creates link within li, and gives li 'is-active' class if filter is active. 
- Takes optional default_selected_link parameter. Mark given link as active when no filter is queried (for example: if there is 'all' filter it can be highlighted as active even if it's not queried in url params)
- Clicking on active link/filter removes filter
- Works with pagination (does not break after filter is selected when user is on page not filled by new filter criteria)
- Is reusable across app. Infers controller from request params and takes filter_key as constructor parameter.

![filter_rewards_by_category](https://user-images.githubusercontent.com/22965927/185714947-d7cd886a-8a32-433d-a6f9-6b56cdc5791d.gif)
