### PR TITLE
Admin can export orders to a csv

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,15 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="HtmlUnknownAttribute" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="myValues">
+        <value>
+          <list size="1">
+            <item index="0" class="java.lang.String" itemvalue="test_id" />
+          </list>
+        </value>
+      </option>
+      <option name="myCustomValuesEnabled" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -3,6 +3,8 @@
   <component name="CommitMessageInspectionProfile">
     <profile version="1.0">
       <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
       <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
     </profile>
   </component>

--- a/app/controllers/admins/orders_controller.rb
+++ b/app/controllers/admins/orders_controller.rb
@@ -10,6 +10,10 @@ module Admins
       redirect_back fallback_location: admins_orders_path
     end
 
+    def csv_export
+      send_data Order.to_csv, filename: "orders-#{Time.zone.today}.csv"
+    end
+
     private
 
     def order

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,3 +1,4 @@
+require 'csv'
 class Order < ApplicationRecord
   belongs_to :employee
   belongs_to :reward
@@ -9,5 +10,16 @@ class Order < ApplicationRecord
     return unless reward.present? && employee.present? && (reward.price > employee.points)
 
     errors.add(:can_not_afford, 'You can not afford this reward')
+  end
+
+  def self.to_csv
+    attributes = %w[employee_id reward_id purchase_price status created_at updated_at]
+
+    CSV.generate(headers: true) do |csv|
+      csv << attributes
+      all.find_each do |order|
+        csv << attributes.map { |attribute| order.send(attribute) }
+      end
+    end
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,10 +1,13 @@
 require 'csv'
+
 class Order < ApplicationRecord
   belongs_to :employee
   belongs_to :reward
   enum status: { placed: 0, delivered: 1 }, _suffix: false
 
   validate :can_employee_afford_price, on: :create
+
+  EXPORT_ATTRIBUTES = %w[employee_id reward_id purchase_price status created_at updated_at].freeze
 
   def can_employee_afford_price
     return unless reward.present? && employee.present? && (reward.price > employee.points)
@@ -13,12 +16,10 @@ class Order < ApplicationRecord
   end
 
   def self.to_csv
-    attributes = %w[employee_id reward_id purchase_price status created_at updated_at]
-
     CSV.generate(headers: true) do |csv|
-      csv << attributes
+      csv << EXPORT_ATTRIBUTES
       all.find_each do |order|
-        csv << attributes.map { |attribute| order.send(attribute) }
+        csv << EXPORT_ATTRIBUTES.map { |attribute| order.send(attribute) }
       end
     end
   end

--- a/app/views/admins/orders/index.html.erb
+++ b/app/views/admins/orders/index.html.erb
@@ -3,6 +3,9 @@
     <div class="level-left">
       <p class='is-size-3'><strong>Orders</strong></p>
     </div>
+    <div class="level-right">
+      <%= link_to 'Export to CSV', csv_export_admins_orders_path, class: "button is-outlined" %>
+    </div>
   </nav>
   <div class='box'>
     <div class="list has-hoverable-list-items has-visible-pointer-controls">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
     resources :rewards
     resources :orders, only: %i[index] do
         put 'deliver', on: :member
+        get 'csv_export', on: :collection, to: 'orders#csv_export'
     end
     resources :categories
     root to: 'pages#dashboard'

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe Order, type: :model do
   let(:employee) { create(:employee) }
-  let(:expensive_reward) { create(:reward, price: 100) }
 
   # rubocop:disable RSpec/ImplicitExpect
   describe 'validations' do
@@ -10,4 +9,19 @@ RSpec.describe Order, type: :model do
     it { should belong_to(:reward) }
   end
   # rubocop:enable RSpec/ImplicitExpect
+
+  it '.to_csv creates CSV file with proper values and all orders' do
+    order = create(:order, :skip_validate)
+    expect(described_class.to_csv.lines.count).to be 2 # header row + 1 data row
+    expect(described_class.to_csv).to include(CSV.generate_line([
+                                                                  order.employee_id,
+                                                                  order.reward_id,
+                                                                  order.purchase_price,
+                                                                  order.status,
+                                                                  order.created_at,
+                                                                  order.updated_at
+                                                                ]))
+    create_list(:order, 2, :skip_validate)
+    expect(described_class.to_csv.lines.count).to be 4 # header row + 3 data rows
+  end
 end

--- a/spec/system/admins/orders/index_spec.rb
+++ b/spec/system/admins/orders/index_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Admin can deliver placed orders', type: :system do
+describe 'When admin is on index page', type: :system do
   before do
     sign_in admin
     create_list(:kudo, 2, reciever: employee)
@@ -12,16 +12,15 @@ describe 'Admin can deliver placed orders', type: :system do
   let(:reward) { create(:reward) }
   let(:order) { build(:order) }
 
-  context 'when admin goes to orders list' do
-    it 'show all orders' do
-      visit admins_orders_path
-      expect(page).to have_selector(:css, "div[test_id^='order_']", count: 2)
-      expect(page).to have_content(reward.title, count: 2)
-      expect(page).to have_content(reward.description, count: 2)
-      expect(page).to have_content("Price: #{reward.price}", count: 2)
-      expect(page).to have_content(order.created_at.strftime('%F'), count: 2)
-      expect(page).to have_link('Deliver', count: 2, exact: true)
-    end
+  it 'show all orders and Export to CSV button' do
+    visit admins_orders_path
+    expect(page).to have_selector(:css, "div[test_id^='order_']", count: 2)
+    expect(page).to have_content(reward.title, count: 2)
+    expect(page).to have_content(reward.description, count: 2)
+    expect(page).to have_content("Price: #{reward.price}", count: 2)
+    expect(page).to have_content(order.created_at.strftime('%F'), count: 2)
+    expect(page).to have_link('Deliver', count: 2, exact: true)
+    expect(page).to have_link('Export to CSV')
   end
 
   context 'when admin delivers order' do


### PR DESCRIPTION
Sprint 7, task 2

Admin can export orders to CSV with all it's fields with button on Orders#index page.

New action csv_export in controller calls Order 'to_csv' method that generates CSV with all records and header row. 
Includes with matching route and tests.

![orders_csv_export](https://user-images.githubusercontent.com/22965927/189733988-201fa918-ace6-4a62-a417-9bced2ae1d6d.gif)