### PR TITLE
Feature/import rewards from csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,7 +116,8 @@ yarn-debug.log*
 # Ignore uploaded files in development
 /storage/*
 !/storage/.keep
-/public/uploads
+/public/uploads/*
+!/public/uploads/.keep
 
 ### RubyMine ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider

--- a/app/controllers/admins/rewards_controller.rb
+++ b/app/controllers/admins/rewards_controller.rb
@@ -58,7 +58,6 @@ module Admins
       else
         render :upload_rewards, locals: { errors: service.errors }
       end
-      redirect_to admins_rewards_path, alert: 'Something went wrong. Try again later.'
     end
 
     private

--- a/app/controllers/admins/rewards_controller.rb
+++ b/app/controllers/admins/rewards_controller.rb
@@ -51,7 +51,7 @@ module Admins
       uploaded_file_path = Rails.root.join('public', 'uploads', uploaded_file.original_filename)
       File.binwrite(uploaded_file_path, uploaded_file.read)
 
-      service = ImportRewardsService.new(uploaded_file_path)
+      service = ImportRewardsService.new(uploaded_file_path, params[:headers])
       if service.call
         redirect_to admins_rewards_path,
                     notice: "#{service.record_count} #{'reward'.pluralize(service.record_count)} imported"

--- a/app/controllers/admins/rewards_controller.rb
+++ b/app/controllers/admins/rewards_controller.rb
@@ -53,7 +53,8 @@ module Admins
 
       service = ImportRewardsService.new(uploaded_file_path)
       if service.call
-        redirect_to admins_rewards_path, notice: 'Rewards were successfully uploaded.'
+        redirect_to admins_rewards_path,
+                    notice: "#{service.record_count} #{'reward'.pluralize(service.record_count)} imported"
       else
         render :upload_rewards, locals: { errors: service.errors }
       end

--- a/app/controllers/admins/rewards_controller.rb
+++ b/app/controllers/admins/rewards_controller.rb
@@ -44,6 +44,22 @@ module Admins
       redirect_to admins_rewards_path, notice: 'Reward was successfully destroyed.'
     end
 
+    def upload_rewards; end
+
+    def import_from_csv
+      uploaded_file = params[:rewards_csv]
+      uploaded_file_path = Rails.root.join('public', 'uploads', uploaded_file.original_filename)
+      File.binwrite(uploaded_file_path, uploaded_file.read)
+
+      service = ImportRewardsService.new(uploaded_file_path)
+      if service.call
+        redirect_to admins_rewards_path, notice: 'Rewards were successfully uploaded.'
+      else
+        render :upload_rewards, locals: { errors: service.errors }
+      end
+      redirect_to admins_rewards_path, alert: 'Something went wrong. Try again later.'
+    end
+
     private
 
     def find_reward

--- a/app/models/reward.rb
+++ b/app/models/reward.rb
@@ -3,9 +3,9 @@ class Reward < ApplicationRecord
   has_many :categories, through: :category_rewards
   has_one_attached :image
 
-  validates :title, :description, :price, presence: true
+  validates :title, :description, :price, :categories, presence: true
+  validates :title, uniqueness: true
   validates :price, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
-  validates :categories, presence: true
   validate :image_format
 
   paginates_per 3

--- a/app/services/import_rewards_service.rb
+++ b/app/services/import_rewards_service.rb
@@ -1,0 +1,91 @@
+require 'csv'
+
+class ImportRewardsService
+  attr_reader :errors, :record_count
+
+  def initialize(source, headers)
+    @source = source
+    @headers = !headers.nil?
+    @errors = []
+    @record_count = []
+    @imported_rewards_attributes = []
+    @imported_rewards = []
+  end
+
+  def call
+    parse_rewards_attributes
+    validate_titles_uniqueness
+    return false if @errors.any?
+
+    build_reward_objects
+    transaction_with_error_handling do
+      @imported_rewards.each(&:save!)
+    end
+  end
+
+  private
+
+  def parse_rewards_attributes
+    header_converter = ->(header) { header.strip.downcase.singularize }
+    row_converter = ->(field) { (field || '').strip }
+    begin
+      CSV.foreach(@source, converters: row_converter, headers: @headers, header_converters: header_converter,
+                           skip_blanks: true,
+                           empty_value: '') do |row|
+        @imported_rewards_attributes.push({
+          title: (row[@headers ? 'title' : 0]),
+          description: (row[@headers ? 'description' : 1]),
+          price: (row[@headers ? 'price' : 2]),
+          categories: (row[@headers ? 'category' : 3])
+        })
+      end
+    rescue CSV::MalformedCSVError => e
+      failure(e.message)
+      false
+    end
+  end
+
+  def validate_titles_uniqueness
+    titles = []
+    @imported_rewards_attributes.each do |entry|
+      if titles.include?(entry[:title])
+        @errors.push(
+          "Duplicated entry with title '#{entry[:title]}'. Rewards names must be unique."
+        )
+      end
+      titles.push(entry[:title])
+    end
+  end
+
+  def build_reward_objects
+    @imported_rewards_attributes.each do |entry|
+      reward = Reward.find_or_initialize_by(title: entry[:title])
+      reward.description = entry[:description]
+      reward.price = entry[:price]
+      categories = []
+      entry[:categories].split.each do |category|
+        categories << Category.find_by(title: category)
+      end
+      if categories.any?(&:nil?)
+        reward.categories.clear
+      else
+        reward.categories = categories
+      end
+      @imported_rewards << reward
+    end
+    @record_count = @imported_rewards.size
+  end
+
+  def transaction_with_error_handling(&block)
+    ActiveRecord::Base.transaction(requires_new: true, &block)
+  rescue ActiveRecord::ActiveRecordError => e
+    message = "#{'Error'.pluralize(e.record.errors.size)} for '#{e.record.title}':
+                  #{e.record.errors.full_messages.join('; ')}"
+    failure(message)
+  end
+
+  def failure(message)
+    errors.push(message)
+    false
+  end
+end

--- a/app/services/import_rewards_service.rb
+++ b/app/services/import_rewards_service.rb
@@ -1,0 +1,44 @@
+require 'csv'
+
+class ImportRewardsService
+  attr_reader :errors
+
+  def initialize(source)
+    @source = source
+    @errors = []
+  end
+
+  def call
+    validate_headers
+    import_from_source
+
+    transaction_with_error_handling do
+      @imported_rewards.save!
+    end
+  end
+
+  private
+
+  def import_from_source
+    @imported_rewards = []
+    CSV.foreach(@source, headers: true) do |row|
+      @imported_rewards.push(Reward.new(
+                               title: row['title'],
+                               description: row['description'],
+                               price: row['price'],
+                               categories: Category.where(title: row['categories'].split)
+                             ))
+    end
+  end
+
+  def transaction_with_error_handling(&block)
+    ActiveRecord::Base.transaction(requires_new: true, &block)
+  rescue ActiveRecord::ActiveRecordError => e
+    failure(e.message)
+  end
+
+  def failure(message)
+    errors.push(message)
+    false
+  end
+end

--- a/app/services/import_rewards_service.rb
+++ b/app/services/import_rewards_service.rb
@@ -79,8 +79,8 @@ class ImportRewardsService
   def transaction_with_error_handling(&block)
     ActiveRecord::Base.transaction(requires_new: true, &block)
   rescue ActiveRecord::ActiveRecordError => e
-    message = "#{'Error'.pluralize(e.record.errors.size)} for '#{e.record.title}':
-                  #{e.record.errors.full_messages.join('; ')}"
+    message = "#{'Error'.pluralize(e.record.errors.size)} for '#{e.record.title}': "\
+              "#{e.record.errors.full_messages.join('; ')}"
     failure(message)
   end
 

--- a/app/services/import_rewards_service.rb
+++ b/app/services/import_rewards_service.rb
@@ -79,7 +79,7 @@ class ImportRewardsService
   def transaction_with_error_handling(&block)
     ActiveRecord::Base.transaction(requires_new: true, &block)
   rescue ActiveRecord::ActiveRecordError => e
-    message = "#{'Error'.pluralize(e.record.errors.size)} for '#{e.record.title}': "\
+    message = "#{'Error'.pluralize(e.record.errors.size)} for '#{e.record.title}': " \
               "#{e.record.errors.full_messages.join('; ')}"
     failure(message)
   end

--- a/app/views/admins/rewards/index.html.erb
+++ b/app/views/admins/rewards/index.html.erb
@@ -5,6 +5,7 @@
     </div>
     <div class="level-right">
       <%= link_to 'New Reward', new_admins_reward_path, class: 'button is-primary level-item' %>
+      <%= link_to 'Import rewards from CSV', upload_rewards_admins_rewards_path, class: 'button level-item' %>
     </div>
   </nav>
   <div class='box'>

--- a/app/views/admins/rewards/upload_rewards.html.erb
+++ b/app/views/admins/rewards/upload_rewards.html.erb
@@ -1,28 +1,42 @@
 <div class='section'>
   <p class='is-size-3'><strong>Import Rewards from CSV</strong></p>
 
+  <div class="block">
+    <b>Data formatting:</b><br>
+    Accepted headers: title, description, price, category. All other columns will be ignored.<br>
+    Leading and trailing spaces will be removed.<br>
+    File without headers must have data in order: title, description, price, category.<br>
+    Columns separator is comma ','.<br>
+    Fields that contain a special character (comma, newline, or double quote), must be enclosed in double quotes.<br>
+    <b>If file has headers mark box below.</b>
+
+  </div>
+
   <% if local_variables.include?(:errors) %>
-    <div class='help is-danger'>
-      <% errors.each do |message| %>
-        <%= message %><br>
-      <% end %>
+    <div class="block">
+      <div class='help is-danger'>
+        <% errors.each do |message| %>
+          <%= message %><br>
+        <% end %>
+      </div>
     </div>
   <% end %>
+  <div class="block">
+    <%= form_with(url: { action: :import_from_csv }, multipart: true) do %>
+      <div class="field">
+        <%= file_field_tag 'rewards_csv', accept: 'text/csv', test_id: "rewards_csv_input" %>
+      </div>
+      <div>
+        <%= check_box_tag 'headers' %>
+        <%= label_tag 'headers', 'File with headers' %>
+      </div>
+      <div class="actions mt-3">
+        <%= submit_tag "Import selected file", class: "button is-primary" %>
+      </div>
+    <% end %>
 
-  <%= form_with(url: {action: :import_from_csv}, multipart: true) do %>
-    <div class="field">
-    <%= file_field_tag 'rewards_csv', accept: 'text/csv', test_id: "rewards_csv_input" %>
+    <div class='mt-3'>
+      <%= link_to 'Back', admins_rewards_path, class: 'button' %>
     </div>
-    <div>
-      <%= check_box_tag 'headers' %>
-      <%= label_tag 'headers', 'File with headers' %>
-    </div>
-    <div class="actions">
-      <%= submit_tag "Import selected file", class: "button is-primary" %>
-    </div>
-  <% end %>
-
-  <div class='mt-3'>
-    <%= link_to 'Back', admins_rewards_path, class: 'button' %>
   </div>
 </div>

--- a/app/views/admins/rewards/upload_rewards.html.erb
+++ b/app/views/admins/rewards/upload_rewards.html.erb
@@ -3,7 +3,7 @@
 
   <% if local_variables.include?(:errors) %>
     <div class='help is-danger'>
-      <% errors.full_messages_for(:image).each do |message| %>
+      <% errors.each do |message| %>
         <%= message %><br>
       <% end %>
     </div>
@@ -12,6 +12,10 @@
   <%= form_with(url: {action: :import_from_csv}, multipart: true) do %>
     <div class="field">
     <%= file_field_tag 'rewards_csv', accept: 'text/csv', test_id: "rewards_csv_input" %>
+    </div>
+    <div>
+      <%= check_box_tag 'headers' %>
+      <%= label_tag 'headers', 'File with headers' %>
     </div>
     <div class="actions">
       <%= submit_tag "Import selected file", class: "button is-primary" %>

--- a/app/views/admins/rewards/upload_rewards.html.erb
+++ b/app/views/admins/rewards/upload_rewards.html.erb
@@ -1,0 +1,16 @@
+<div class='section'>
+  <p class='is-size-3'><strong>Import Rewards from CSV</strong></p>
+
+  <%= form_with(url: {action: :import_from_csv}, multipart: true) do %>
+    <div class="field">
+    <%= file_field_tag 'rewards_csv', accept: 'text/csv', test_id: "rewards_csv_input" %>
+    </div>
+    <div class="actions">
+      <%= submit_tag "Import selected file", class: "button is-primary" %>
+    </div>
+  <% end %>
+
+  <div class='mt-3'>
+    <%= link_to 'Back', admins_rewards_path, class: 'button' %>
+  </div>
+</div>

--- a/app/views/admins/rewards/upload_rewards.html.erb
+++ b/app/views/admins/rewards/upload_rewards.html.erb
@@ -1,6 +1,14 @@
 <div class='section'>
   <p class='is-size-3'><strong>Import Rewards from CSV</strong></p>
 
+  <% if local_variables.include?(:errors) %>
+    <div class='help is-danger'>
+      <% errors.full_messages_for(:image).each do |message| %>
+        <%= message %><br>
+      <% end %>
+    </div>
+  <% end %>
+
   <%= form_with(url: {action: :import_from_csv}, multipart: true) do %>
     <div class="field">
     <%= file_field_tag 'rewards_csv', accept: 'text/csv', test_id: "rewards_csv_input" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,10 @@ Rails.application.routes.draw do
       patch 'add_kudos', on: :collection
     end
     resources :company_values
-    resources :rewards
+    resources :rewards do
+      get 'upload_rewards', on: :collection
+      post 'import_from_csv', on: :collection
+    end
     resources :orders, only: %i[index] do
         put 'deliver', on: :member
         get 'csv_export', on: :collection, to: 'orders#csv_export'

--- a/db/migrate/20220925143935_add_unique_index_on_rewards_title.rb
+++ b/db/migrate/20220925143935_add_unique_index_on_rewards_title.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexOnRewardsTitle < ActiveRecord::Migration[6.1]
+  def change
+    add_index :rewards, :title, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_22_180247) do
+ActiveRecord::Schema.define(version: 2022_09_25_143935) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -123,6 +123,7 @@ ActiveRecord::Schema.define(version: 2022_08_22_180247) do
     t.integer "price", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["title"], name: "index_rewards_on_title", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/factories/factory_sequences.rb
+++ b/spec/factories/factory_sequences.rb
@@ -11,4 +11,7 @@ FactoryBot.define do
   sequence :category_title do |n|
     "Category#{n}"
   end
+  sequence :reward_title do |n|
+    "Reward_#{n}"
+  end
 end

--- a/spec/factories/reward_factory.rb
+++ b/spec/factories/reward_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
       categories_count { 2 }
     end
 
-    title { 'Reward title' }
+    title { generate(:reward_title) }
     description { 'Reward description' }
     price { 1 }
 

--- a/spec/fixtures/files/duplicated_titles_rewards.csv
+++ b/spec/fixtures/files/duplicated_titles_rewards.csv
@@ -1,0 +1,3 @@
+first Reward,from headers file,2,junk
+second Reward,test description,2,junk
+second Reward,test description,2,junk

--- a/spec/fixtures/files/invalid_quoting_rewards.csv
+++ b/spec/fixtures/files/invalid_quoting_rewards.csv
@@ -1,0 +1,2 @@
+first Reward,from headers file,2,junk
+second "Reward",test description,2,junk

--- a/spec/fixtures/files/missing_values_rewards.csv
+++ b/spec/fixtures/files/missing_values_rewards.csv
@@ -1,0 +1,2 @@
+first Reward,from headers file,2,junk
+second Reward,,2,junk

--- a/spec/fixtures/files/rewards.csv
+++ b/spec/fixtures/files/rewards.csv
@@ -1,0 +1,2 @@
+title,description,price,category
+imported Reward,from headers file,2,junk

--- a/spec/fixtures/files/rewards_noheaders.csv
+++ b/spec/fixtures/files/rewards_noheaders.csv
@@ -1,0 +1,1 @@
+imported Reward,from no headers file,20,treasure

--- a/spec/models/reward_spec.rb
+++ b/spec/models/reward_spec.rb
@@ -2,10 +2,13 @@ require 'rails_helper'
 
 RSpec.describe Reward, type: :model do
   describe 'validations' do
+    subject { build(:reward) }
+
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:description) }
     it { is_expected.to validate_presence_of(:price) }
     it { is_expected.to validate_presence_of(:categories) }
+    it { is_expected.to validate_uniqueness_of(:title) }
 
     # rubocop:disable RSpec/ImplicitSubject
     it do

--- a/spec/services/import_rewards_service_spec.rb
+++ b/spec/services/import_rewards_service_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe ImportRewardsService, type: :model do
+  describe '#call' do
+    it 'imports records from valid files' do
+      create(:category, title: 'junk')
+      source = Rails.root.join('spec/fixtures/files/rewards.csv')
+      headers = true
+      expect { described_class.new(source, headers).call }.to change { Reward.all.count }.by(1)
+    end
+
+    it 'rollbacks transaction and shows errors when fails' do
+      create(:category, title: 'junk')
+      source = Rails.root.join('spec/fixtures/files/invalid_quoting_rewards.csv')
+      headers = nil
+      service = described_class.new(source, headers)
+      expect { service.call }.not_to change { Reward.all.count }
+      expect(service.errors).to include('Illegal quoting in line 2.')
+
+      source = Rails.root.join('spec/fixtures/files/duplicated_titles_rewards.csv')
+      service = described_class.new(source, headers)
+      expect { service.call }.not_to change { Reward.all.count }
+      expect(service.errors).to include("Duplicated entry with title 'second Reward'. Rewards names must be unique.")
+
+      source = Rails.root.join('spec/fixtures/files/missing_values_rewards.csv')
+      service = described_class.new(source, headers)
+      expect { service.call }.not_to change { Reward.all.count }
+      expect(service.errors).to include("Error for 'second Reward': Description can't be blank")
+    end
+  end
+end

--- a/spec/system/admins/orders/index_spec.rb
+++ b/spec/system/admins/orders/index_spec.rb
@@ -15,7 +15,7 @@ describe 'When admin is on index page', type: :system do
   it 'show all orders and Export to CSV button' do
     visit admins_orders_path
     expect(page).to have_selector(:css, "div[test_id^='order_']", count: 2)
-    expect(page).to have_content(reward.title, count: 2)
+    expect(page).to have_content('Reward_', count: 2)
     expect(page).to have_content(reward.description, count: 2)
     expect(page).to have_content("Price: #{reward.price}", count: 2)
     expect(page).to have_content(order.created_at.strftime('%F'), count: 2)

--- a/spec/system/admins/reward/import_rewards_from_csv_spec.rb
+++ b/spec/system/admins/reward/import_rewards_from_csv_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe 'import rewards from CSV', type: :system, js: true do
+  before do
+    sign_in admin
+  end
+
+  let(:admin) { create(:admin) }
+  let(:reward) { create(:reward) }
+
+  it 'Admin can import rewards from CSV' do
+    create(:category, title: 'junk')
+    create(:category, title: 'treasure')
+    visit admins_root_path
+    page.find(:css, "div[test_id='admin_panel']").click
+    within(:css, "div[test_id='admin_panel']") do
+      click_on 'Rewards'
+    end
+    click_on 'Import rewards from CSV'
+    attach_file('rewards_csv', Rails.root.join('spec/fixtures/files/rewards.csv'))
+    check 'headers'
+    click_on 'Import selected file'
+
+    expect(page).to have_content 'imported Reward', count: 1
+    expect(page).to have_content 'from headers file'
+    expect(page).to have_content '1'
+    expect(page).to have_content 'junk'
+
+    click_on 'Import rewards from CSV'
+    attach_file('rewards_csv', Rails.root.join('spec/fixtures/files/rewards_noheaders.csv'))
+    uncheck 'headers'
+    click_on 'Import selected file'
+    expect(page).to have_content 'imported Reward', count: 1
+    expect(page).to have_content 'from no headers file'
+    expect(page).to have_content '20'
+    expect(page).to have_content 'treasure'
+  end
+end

--- a/spec/system/orders/index_spec.rb
+++ b/spec/system/orders/index_spec.rb
@@ -19,7 +19,7 @@ describe 'Employee can list bought rewards', type: :system, js: true do
     it 'show all employees orders and highlights all' do
       visit orders_path
       expect(page).to have_selector(:css, "div[test_id^='order_']", count: 3)
-      expect(page).to have_content(reward.title, count: 3)
+      expect(page).to have_content('Reward_', count: 3)
       expect(page).to have_content(reward.description, count: 3)
       expect(page).to have_content("Price: #{reward.price}", count: 3)
       expect(page).to have_content(order.created_at.strftime('%F'), count: 3)


### PR DESCRIPTION
Sprint 7, task 3: Admin can import rewards from a csv.

Task allows admin to import reward from CSV. Add a view with a form and description of CSV formatting. 
Importing file is done in service object. Persistence of records is done in transaction, all records must be valid to import any data. Validation and parsing errors are show to admin. Confirmation flash displays number of imported rewards.

Leading and trailing spaces is stripped from data, CSV can have headers. 

***Change to Rewards model: Title must be unique.***
![impoer_rewards_from_csv](https://user-images.githubusercontent.com/22965927/192361402-f05ebdc2-e852-4be9-a484-7384e51e987c.gif)


